### PR TITLE
Fixing tab-to-spaces errors

### DIFF
--- a/data/korath ships.txt
+++ b/data/korath ships.txt
@@ -131,48 +131,48 @@ ship "Korath Chaser"
 
 
 ship "Korath Hunter"
-    sprite "ship/hunter"
-    attributes
-        category "Interceptor"        
-        "cost" 1143000        
-        "shields" 3200        
-        "hull" 1300        
-        "required crew" 2        
-        "bunks" 3        
-        "mass" 90        
-        "drag" 2.3        
-        "heat dissipation" .9
-        "cargo space" 26        
-        "outfit space" 218        
-        "weapon capacity" 47        
-        "engine capacity" 45
-        "fuel capacity" 600
-        "ramscoop" 1        
-        weapon            
-            "blast radius" 60            
-            "shield damage" 900            
-            "hull damage" 400            
-            "hit force" 1000
-    outfits        
-        "Korath Fire-Lance" 2    
-    
-        "Generator (Furnace Class)"    
-        "Generator (Candle Class)"
-        "Systems Core (Small)"    
-        "Small Heat Shunt" 2        
-        "Korath Repeater Rifle" 2
-                
-        "Thruster (Comet Class)"        
-        "Steering (Comet Class)"
-        "Hyperdrive"    
+	sprite "ship/hunter"
+	attributes
+		category "Interceptor"
+		"cost" 1143000
+		"shields" 3200
+		"hull" 1300
+		"required crew" 2
+		"bunks" 3
+		"mass" 90
+		"drag" 2.3
+		"heat dissipation" .9
+		"cargo space" 26
+		"outfit space" 218
+		"weapon capacity" 47
+		"engine capacity" 45
+		"fuel capacity" 600
+		"ramscoop" 1
+		weapon
+			"blast radius" 60
+			"shield damage" 900
+			"hull damage" 400
+			"hit force" 1000
+	outfits
+		"Korath Fire-Lance" 2
 
-    engine 0 46
-    engine 10 50 0.5
-    engine -10 50 0.5
-    gun 5 -38 "Korath Fire-Lance"
-    gun -4 -38 "Korath Fire-Lance"
-    explode "tiny explosion" 20    
-    description "These Korath heavy interceptors are seen as far as the Ember Wastes, which they reach by strapping themselves to the hull of larger ships. Groups of young Korath brave the Wastes to test their mettle: those that return are sure to become Raider captains."	
+		"Generator (Furnace Class)"
+		"Generator (Candle Class)"
+		"Systems Core (Small)"
+		"Small Heat Shunt" 2
+		"Korath Repeater Rifle" 2
+
+		"Thruster (Comet Class)"
+		"Steering (Comet Class)"
+		"Hyperdrive"
+
+	engine 0 46
+	engine 10 50 0.5
+	engine -10 50 0.5
+	gun 5 -38 "Korath Fire-Lance"
+	gun -4 -38 "Korath Fire-Lance"
+	explode "tiny explosion" 20
+	description "These Korath heavy interceptors are seen as far as the Ember Wastes, which they reach by strapping themselves to the hull of larger ships. Groups of young Korath brave the Wastes to test their mettle: those that return are sure to become Raider captains."
 
 
 	

--- a/data/korath.txt
+++ b/data/korath.txt
@@ -202,69 +202,69 @@ fleet "Korath Raid"
 		"Korath Chaser" 2
 
 fleet "Korath Home"
-    government "Korath"
-    names "korath"
-    fighters "korath"
-    cargo 3
-    personality
-        timid opportunistic
-    variant 12
-        "Korath World-Ship"
-    variant 12
-        "Korath World-Ship B"
-    variant 12
-        "Korath World-Ship C"
-    variant 4
-        "Korath World-Ship"
-        "Korath Hunter" 4
-    variant 4
-        "Korath World-Ship B"
-        "Korath Hunter" 4
-    variant 4
-        "Korath World-Ship C"
-        "Korath Hunter" 4        
-    variant 2
-        "Korath World-Ship"
-        "Korath Hunter" 6
-    variant 2
-        "Korath World-Ship B"
-        "Korath Hunter" 6
-    variant 2
-        "Korath World-Ship C"
-        "Korath Hunter" 6     
+	government "Korath"
+	names "korath"
+	fighters "korath"
+	cargo 3
+	personality
+		timid opportunistic
+	variant 12
+		"Korath World-Ship"
+	variant 12
+		"Korath World-Ship B"
+	variant 12
+		"Korath World-Ship C"
+	variant 4
+		"Korath World-Ship"
+		"Korath Hunter" 4
+	variant 4
+		"Korath World-Ship B"
+		"Korath Hunter" 4
+	variant 4
+		"Korath World-Ship C"
+		"Korath Hunter" 4		
+	variant 2
+		"Korath World-Ship"
+		"Korath Hunter" 6
+	variant 2
+		"Korath World-Ship B"
+		"Korath Hunter" 6
+	variant 2
+		"Korath World-Ship C"
+		"Korath Hunter" 6	 
 
 
 fleet "Korath Ember Wastes"
-    government "Korath"
-    names "korath"
-    fighters "korath"
-    cargo 1
-    personality
-        disables plunders opportunistic harvests
-    variant
-        "Korath Hunter" 4    
-    variant
-        "Korath Hunter" 6    
+	government "Korath"
+	names "korath"
+	fighters "korath"
+	cargo 1
+	personality
+		disables plunders opportunistic harvests
+	variant
+		"Korath Hunter" 4	
+	variant
+		"Korath Hunter" 6	
 
 
 fleet "Korath Raid Remnant"
-    government "Korath"
-    names "korath"
-    fighters "korath"
-    cargo 1
-    personality
-        disables plunders opportunistic harvests
-    variant 4
-        "Korath Raider"
-        "Korath Chaser" 2
-        "Korath Hunter" 3
-    variant 3
-        "Korath Raider"
-        "Korath Chaser" 2
-    variant 3
-        "Korath Hunter" 6        
-    variant 2
-        "Korath Hunter" 10		
+	government "Korath"
+	names "korath"
+	fighters "korath"
+	cargo 1
+	personality
+		disables plunders opportunistic harvests
+	variant 4
+		"Korath Raider"
+		"Korath Chaser" 2
+		"Korath Hunter" 3
+	variant 3
+		"Korath Raider"
+		"Korath Chaser" 2
+	variant 3
+		"Korath Hunter" 6		
+	variant 2
+		"Korath Hunter" 10		
 
 		
 fleet "Kor Efret Home"

--- a/data/map.txt
+++ b/data/map.txt
@@ -4379,7 +4379,7 @@ system Arculus
 	trade Plastic 498
 	fleet "Large Remnant" 1500
 	fleet "Small Remnant" 1000
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/g5-old
 		period 10
@@ -5855,8 +5855,8 @@ system Caeculus
 	trade Metal 272
 	trade Plastic 289
 	fleet "Korath Raid" 20000
-    fleet "Korath Raid Remnant" 30000
-    fleet "Korath Ember Wastes" 5000
+	fleet "Korath Raid Remnant" 30000
+	fleet "Korath Ember Wastes" 5000
 	object
 		sprite star/wr
 		period 10
@@ -6718,7 +6718,7 @@ system Cinxia
 	fleet "Large Remnant" 1200
 	fleet "Small Remnant" 900
 	fleet "Korath Raid" 30000
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/k5-old
 		period 10
@@ -8216,7 +8216,7 @@ system Edusa
 	trade Plastic 475
 	fleet "Large Remnant" 3000
 	fleet "Small Remnant" 2000
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/giant
 		period 10
@@ -9502,7 +9502,7 @@ system Farinus
 	trade Plastic 354
 	fleet "Large Remnant" 9000
 	fleet "Small Remnant" 7000
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/k5-old
 		distance 36.894
@@ -14069,7 +14069,7 @@ system Levana
 	trade Metal 407
 	trade Plastic 222
 	fleet "Korath Raid" 10000
-    fleet "Korath Ember Wastes" 8000
+	fleet "Korath Ember Wastes" 8000
 	object
 		sprite star/giant
 		distance 17.197
@@ -14379,7 +14379,7 @@ system Lucina
 	trade Metal 524
 	trade Plastic 410
 	fleet "Korath Raid" 20000
-    fleet "Korath Ember Wastes" 15000
+	fleet "Korath Ember Wastes" 15000
 	object
 		sprite star/m0
 		period 10
@@ -17000,7 +17000,7 @@ system Pantica
 	trade Plastic 469
 	fleet "Large Remnant" 1000
 	fleet "Small Remnant" 700
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/k0-old
 		period 10
@@ -17050,9 +17050,9 @@ system Parca
 	trade Medical 872
 	trade Metal 531
 	trade Plastic 445
-    fleet "Korath Raid" 10000
-    fleet "Korath Raid Remnant" 30000
-    fleet "Korath Ember Wastes" 8000
+	fleet "Korath Raid" 10000
+	fleet "Korath Raid Remnant" 30000
+	fleet "Korath Ember Wastes" 8000
 	object
 		sprite star/g5-old
 		distance 18.2961
@@ -17266,7 +17266,7 @@ system Peragenor
 	trade Medical 512
 	trade Metal 271
 	trade Plastic 373
-    fleet "Korath Ember Wastes" 8000
+	fleet "Korath Ember Wastes" 8000
 	object
 		sprite star/g0-old
 		period 10
@@ -17369,7 +17369,7 @@ system Perfica
 	fleet "Large Remnant" 8000
 	fleet "Small Remnant" 5000
 	fleet "Korath Raid" 30000
-    fleet "Korath Raid Remnant" 30000
+	fleet "Korath Raid Remnant" 30000
 	object
 		sprite star/g0-old
 		period 10
@@ -19834,8 +19834,8 @@ system Segesta
 	trade Medical 664
 	trade Metal 406
 	trade Plastic 295
-    fleet "Small Remnant" 10000
-    fleet "Korath Ember Wastes" 7000
+	fleet "Small Remnant" 10000
+	fleet "Korath Ember Wastes" 7000
 	object
 		sprite star/k5-old
 		period 10
@@ -21505,8 +21505,8 @@ system Stercutus
 	trade Metal 299
 	trade Plastic 294
 	fleet "Korath Raid" 20000
-    fleet "Korath Raid Remnant" 30000
-    fleet "Korath Ember Wastes" 5000
+	fleet "Korath Raid Remnant" 30000
+	fleet "Korath Ember Wastes" 5000
 	fleet "Small Remnant" 10000
 	object
 		sprite star/g5-old


### PR DESCRIPTION
It appears that a bunch of the stuff related to adding in the Korath Hunter (basically all the copied code) converted the tabs into spaces. This patch fixes that so they are all back to being tabs. Also deleted a bunch of extraneous tab/spaces trailing the content on some lines.