### PR TITLE
Adding EMP Torpedos to the Remnant

### DIFF
--- a/remnant.txt
+++ b/remnant.txt
@@ -142,6 +142,8 @@ shipyard "Remnant Gascraft"
 	"Gascraft"
 
 outfitter "Remnant"
+	"EMP Torpedo Bay"
+	"EMP Torpedo"
 	"Inhibitor Cannon"
 	"Thrasher Cannon"
 	"Thrasher Turret"


### PR DESCRIPTION
Adds the EMP Torpedo and Bay to the Remnant Outfitter