### PR TITLE
Proposed changes

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -167,6 +167,92 @@ effect "point defense die"
 	"velocity scale" .2
 
 
+outfit "EMP Torpedo"
+	plural "EMP Torpedoes"
+	category "Ammunition"
+	cost 4400
+	thumbnail "outfit/emp torpedo"
+	"mass" 1
+	"emp torpedo capacity" -1
+	description "This is ammunition for the EMP Torpedo Bay, a weapon that is manufactured by the Remnant."
+	
+outfit "EMP Torpedo Bay"
+	category "Secondary Weapons"
+	licenses
+		Remnant
+	cost 583000
+	thumbnail "outfit/emp torpedo bay"
+	"mass" 9
+	"outfit space" -18
+	"weapon capacity" -18
+	"gun ports" -1
+	"emp torpedo capacity" 9
+	weapon
+		sprite "projectile/emp torpedo"
+			"frame rate" 2
+			"no repeat"
+		sound "torpedo"
+		ammo "EMP Torpedo"
+		icon "icon/emp"
+		"fire effect" "emp torpedo fire" 5
+		"hit effect" "nuke explosion"
+		"hit effect" "emp ring" 30
+		"hit effect" "emp spark" 20
+		"die effect" "tiny explosion"
+		stream
+		"reload" 330
+		"firing energy" 400
+		"firing heat" 18
+		"inaccuracy" 5
+		"lifetime" 300
+		"velocity" 7
+		"acceleration" .7
+		"drag" .1
+		"turn" 2
+		"homing" 3
+		"infrared tracking" .7
+		"radar tracking" .8
+		"trigger radius" 50
+		"blast radius" 200
+		"shield damage" 700
+		"hull damage" 100
+		"ion damage" 48
+		"hit force" 90
+		"missile strength" 80
+	description "Electromagnetic pulse weapons were developed by the Remnant during the early days of their colony, when they were living in fear that the Alphas would overrun human space and expand beyond it."
+
+effect "emp torpedo fire"
+	sprite "effect/emp torpedo fire"
+		"no repeat"
+		"frame rate" 10
+	"lifetime" 31
+	"random frame rate" 10
+	"random velocity" 7
+	"random angle" 10
+	"random spin" 2
+
+effect "emp ring"
+	sprite "effect/emp ring"
+		"no repeat"
+		"frame rate" 12
+	"lifetime" 60
+	"random frame rate" 6
+	"velocity scale" 0.1
+	"random angle" 360
+	"random velocity" 4
+
+effect "emp spark"
+	sprite "effect/emp spark"
+		"no repeat"
+		"frame rate" 8
+	"lifetime" 45
+	"random frame rate" 6
+	"velocity scale" 0.1
+	"random angle" 360
+	"random velocity" 7
+
+
+
 # Systems:
 
 outfit "Crystal Capacitor"
@@ -261,19 +347,18 @@ outfit "Scanner Software"
 	category "Systems"
 	licenses
 		Remnant
-	cost 100000
+	cost 230000
 	thumbnail "outfit/scanner software"
 	"mass" 3
 	"outfit space" 3
-	"cargo scan power" 10
+	"cargo scan power" 12
 	"cargo scan speed" 1
-	"outfit scan power" 30
+	"outfit scan power" 12
 	"outfit scan speed" 1
-	"asteroid scan power" 20
-	"tactical scan power" 32
-	"heat generation" 1
-	"energy consumption" -1
+	"tactical scan power" 24
 	description "The Remnant are too few in number to support extensive ground-breaking research in all areas of technology, so they prefer to focus their efforts on a few areas of importance. To make up the deficiency in other areas, the Remnant rely on salvaging and reverse engineering technology from those around them. This software module is a key part of this effort, as it allows any ship the capacity to do detailed scans to determine what they want to target. Its range is shorter than that of dedicated scanning equipment, but it means every Remnant ship can be on the lookout for new technology."
+
+
 
 # Engines:
 

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -49,7 +49,7 @@ ship "Starling"
 		"Crystal Capacitor"
 		"Emergency Ramscoop" 2
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
@@ -80,7 +80,7 @@ ship "Starling" "Starling (Heavy)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
@@ -88,19 +88,21 @@ ship "Starling" "Starling (Heavy)"
 
 ship "Starling" "Starling (Sniper)"
 	outfits
+		"EMP Torpedo Bay"
 		"Inhibitor Cannon" 4
+		"EMP Torpedo" 9
 		
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Smelter-Class Steering"
 		"Hyperdrive"
 	
-	gun 
+	gun "EMP Torpedo Bay"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
@@ -115,7 +117,7 @@ ship "Starling" "Starling (Hunter)"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Emergency Ramscoop"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
@@ -136,7 +138,7 @@ ship "Starling" "Starling (Thrasher)"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
@@ -191,7 +193,7 @@ ship "Albatross"
 		"Crystal Capacitor"
 		"Thermoelectric Cooler" 2
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Smelter-Class Thruster"
 		"Smelter-Class Steering"
@@ -217,19 +219,21 @@ ship "Albatross"
 	explode "large explosion" 40
 	explode "huge explosion" 10
 	"final explode" "final explosion large" 1
-	description "Once they left human space, it became apparent to the Remnant that they would need to build their own shipyards in order to defend themselves if they were discovered by the Alphas or any other unfriendly faction. Using new composite materials that they discovered, they built two new types of ships based on the relics they found: One to explore, and one to defend. The Albatross lacks the range or speed of the Starling, but makes up for it with durability."
+	description "Once they left human space, it became apparent to the Remnant that they would need to build their own shipyards in order to defend themselves if they were discovered by the Alphas or any other unfriendly faction. Using new composite materials that they discovered, they built ships very different from anything seen in human space."
 
 ship "Albatross" "Albatross (Sniper)"
 	outfits
 		"Inhibitor Cannon" 5
+		"EMP Torpedo Bay" 2
 		"Point Defense Turret" 3
+		"EMP Torpedo" 18
 		
 		"Aeon Cell"
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Thermoelectric Cooler" 2
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Crucible-Class Thruster"
@@ -242,8 +246,8 @@ ship "Albatross" "Albatross (Sniper)"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
-	gun 
-	gun 
+	gun "EMP Torpedo Bay"
+	gun "EMP Torpedo Bay"
 	
 	turret "Point Defense Turret"
 	turret "Point Defense Turret"
@@ -262,7 +266,7 @@ ship "Albatross" "Albatross (Turret)"
 		"Crystal Capacitor"
 		"Thermoelectric Cooler"
 		"Outfits Expansion" 2
-		"Scanner software"
+		"Scanner Software"
 		
 		"Smelter-Class Thruster"
 		"Smelter-Class Steering"
@@ -286,7 +290,7 @@ ship "Albatross" "Albatross (Heavy)"
 		"Crystal Capacitor" 2
 		"Thermoelectric Cooler" 2
 		"Outfits Expansion" 4
-		"Scanner software"
+		"Scanner Software"
 		
 		"Forge-Class Thruster"
 		"Crucible-Class Thruster"
@@ -334,10 +338,9 @@ ship "Gascraft"
 		"hull repair rate" 1.2
 		"hull energy" 0.9
 		"gaslining" 1
-		"outfit scan power" 25
+		"outfit scan power" 50
 		"outfit scan speed" 1
-		"asteroid scan power" 42
-		"tactical scan power" 32
+		"tactical scan power" 50
 		"atmosphere scan" 100
 		
 	outfits
@@ -362,59 +365,57 @@ ship "Pelican"
 		category "Heavy Freighter"
 		licenses
 			Remnant
-		cost 34600000
-		"shields" 25000
-		"hull" 11000
+		cost 9770000
+		"shields" 11300
+		"hull" 5700
 		"required crew" 14
-		"bunks" 46
-		"cargo space" 547
-		"mass" 720
-		"drag" 7.0
+		"bunks" 35
+		"cargo space" 302
+		"mass" 320
+		"drag" 7.2
 		"heat dissipation" 0.7
 		"fuel capacity" 600
 		"ramscoop" 3
-		"engine capacity" 217
-		"outfit space" 623
+		"outfit space" 438
 		"weapon capacity" 157
-		"shield generation" 4.2
-		"shield energy" 2.4
-		"hull repair rate" 0.9
-		"hull energy" 0.5
+		"engine capacity" 129
+		"shield generation" 2.7
+		"shield energy" 1.8
+		"hull repair rate" 1
+		"hull energy" 0.75
 		weapon
-			"blast radius" 360
-			"shield damage" 3600
-			"hull damage" 1800
-			"hit force" 5400
+			"blast radius" 160
+			"shield damage" 1600
+			"hull damage" 800
+			"hit force" 2400
 	outfits
-		"Inhibitor Cannon" 2
+		"Thrasher Cannon" 2
 		"Thrasher Turret"
 		"Point Defense Turret" 2
 
 		"Aeon Cell"
-		"Epoch Cell"
-		"Millennium Cell"
-		"Crystal Capacitor" 2
-		"Thermoelectric Cooler" 9
+		"Crystal Capacitor"
+		"Thermoelectric Cooler" 2
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
-		"Scanner software"
+		"Scanner Software"
 
 		"Forge-Class Thruster"
 		"Smelter-Class Steering"
-		Hyperdrive
+		"Hyperdrive"
 
 	engine 22 92 0.7
 	engine -22 92 0.7
 	engine 0 114 1.1
-	gun 8 -135 "Inhibitor Cannon"
-	gun -8 -135 "Inhibitor Cannon"
+	gun 8 -135
+	gun -8 -135
 	turret 0 -67 "Thrasher Turret"
 	turret 56 35 "Point Defense Turret"
 	turret -56 35 "Point Defense Turret"
-	explode "small explosion" 30
-	explode "medium explosion" 60
-	explode "large explosion" 40
-	explode "huge explosion" 10
+	explode "small explosion" 15
+	explode "medium explosion" 30
+	explode "large explosion" 20
+	explode "huge explosion" 5
 	"final explode" "final explosion large" 1
 	description "The Pelican is closely based on the original semi-organic ships the Remnant found in the Ember Wastes. While they are not technically alive, their internal mechanisms and method of construction bear such a close resemblance to living organisms that they are often considered as such. These ships serve as the backbone of Remnant salvage efforts, as well as their resource distribution network."
 

--- a/data/remnant.txt
+++ b/data/remnant.txt
@@ -70,13 +70,14 @@ fleet "Large Remnant"
 		"Albatross (Turret)"
 	variant 2
 		"Pelican" 3
-		"Albatross" 1
+		"Albatross (Heavy)"
 	variant 2
 		"Pelican" 2
-		"Starling" 3
+		"Starling (Thrasher)" 2
+		"Starling (Sniper)"
 	variant 2
-		"Pelican" 1
-		"Starling" 2
+		"Pelican"
+		"Starling (Hunter)" 2
 
 
 


### PR DESCRIPTION
* Changed the Pelican large fleet variants to include ship variants
* Balanced the Scanner Software
  * No longer produces heat or consumes energy, as it now has mass
    * Note: for future reference, `"energy consumption"` values are positive
  * No longer scans asteroids, as the Remnant have no mining fleets
  * Lowered outfit and tactical scan power to be more in line with the mass
  * Increased the cost so that it isn't a clear choice over the same weight in human scanners
  * Ton per ton, Scanner Software is still better than the same weight in human scanners
* Balanced the Pelican so that its stats fit its size
* Fixed the accidental removal of EMPs from the game
* Reverted the changed Albatross description because [this](https://github.com/EndlessSkyCommunity/endless-sky/pull/17/files#r226170234)