### PR TITLE
Dec 09-12 2018 fixes

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -9,7 +9,6 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-
 mission "First Contact: Remnant"
 	landing
 	invisible
@@ -386,7 +385,7 @@ mission "Remnant: Void Sprites 1"
 				`	"What is your name?"`
 					goto name
 
-			`	"Don't worry," he says, "I will find you. You are our only visitor from the outside generations; when you land here, it quickly becomes known."`
+			`	"Don't worry," he says, "I will find you. You are our only visitor from the outside in many decades; when you land here, it quickly becomes known."`
 				accept
 	
 			label name
@@ -586,7 +585,7 @@ mission "Remnant: Heavy Laser"
 					decline
 			
 			`	"Really? Our records indicate that humanity had primitive laser weapons at the time of the Exodus, but nothing that would be considered useful as weapons." She pauses to look down at her scanner. "And yet our scans indicate that they are capable of significant power output.`
-			`	Based on these scans, we may well be able to learn quite a bit from these weapons. Would you be able to acquire a pair of them for us? We could offer you very good compensation for doing so."`
+			`	"Based on these scans, we may well be able to learn quite a bit from these weapons. Would you be able to acquire a pair of them for us? We could offer you very good compensation for doing so."`
 			choice
 				`	"Sure, I would be glad to accept that deal."`
 				`	"Sorry, I'm really not interested in helping Remnant research."`
@@ -620,7 +619,7 @@ mission "Remnant: Catalytic Ramscoop"
 	on offer
 		require "Catalytic Ramscoop"
 		conversation
-			`As you are walking through the spaceport, a woman comes up to you and introduces herself as an engineer at one of the Remnant development labs. She pauses awkwardly before beginning to chant. "As your ship is the only one we have seen in generations that has outfits from ancestral space, we are intrigued by it. Could we take a closer look?"`
+			`As you are walking through the spaceport, a woman comes up to you and introduces herself as an engineer at one of the Remnant development labs. She pauses awkwardly before beginning to chant. "As your ship is the only one we have seen in many decades that has outfits from ancestral space, we are intrigued by it. Could we take a closer look?"`
 			choice
 				`	"Yes, you are welcome to examine it."`
 					goto deep
@@ -641,19 +640,19 @@ mission "Remnant: Catalytic Ramscoop"
 				`	"Sorry, I'm really not interested in helping Remnant research."`
 					decline
 
-			`	After a bit of haggling, she agrees to pay you one and a half million credits in exchange for a cargo of two Deep "Catalytic Ramscoops." Given how cheap they are to purchase in Deep space, you will be earning a very tidy profit on the deal.`
+			`	After a short discussion, she agrees to pay you one million credits in exchange for a cargo of two Deep "Catalytic Ramscoops." Given how cheap they are to purchase in Deep space, you will be earning a very tidy profit on the deal.`
 				accept
 	
 	on complete
 		outfit "Catalytic Ramscoop" -2
-		payment 1500000
+		payment 1000000
 		conversation
 			`You visit the local shipyard and eventually find the engineer busily repairing a damaged Starling. You inform her that you have brought a pair of "Catalytic Ramscoops" for her to study. She quickly tightens a couple more connectors and jumps down from her perch, gesturing at an assistant to transfer you the credits you were promised. "Thank you! Our maps of human space are old, and if they are still accurate, you traveled a very long way to bring these to us." Her chanting voice echoes off the starling above you with an interesting resonance.`
 			`	"Thank you for your help," she says. "If we can unlock the secrets of these scoops, it will give our ships greater range as they search for a safer refuge." As she picks up the remote control for the small loading truck with the two ramscoops she trills at you over her shoulder. "Oh, my name is Tali. I'll let you know what I find."`
 
 mission "Remnant: Plasma Cannons"
 	name "Retrieve Plasma Cannons for the Remnant"
-	description "An engineer on <planet>, a Remnant world, has offered to pay you one million credits in exchange for obtaining two Plasma Cannons."
+	description "An engineer on <planet>, a Remnant world, has offered to pay you 800'000 credits in exchange for obtaining two Plasma Cannons."
 	minor
 	source Viminal
 	to offer
@@ -687,17 +686,17 @@ mission "Remnant: Plasma Cannons"
 				`	"Sorry, I'm really not interested in helping Remnant research."`
 					decline
 
-			`	After a bit of haggling, he agrees to pay you one million credits in exchange for a cargo of two "Plasma Cannons."`
+			`	After a bit of negotiation, he agrees to pay you eight hundred thousand credits in exchange for a cargo of two "Plasma Cannons."`
 				accept
 	
 	on complete
 		outfit "Plasma Cannon" -2
-		payment 1500000
+		payment 1000000
 		conversation
-			`As <ship> settles onto the pad closest to the research facility, you can see the weapons specialist checking over a large cannon on a platform beneath a nearby Albatross. When he sees you starting to unload the two plasma cannons he snaps the casing closed and gestures to someone out of sight. Within moments both him and an empty flatbed are there to pick up the weapons.`
-			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These plasma cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
-			`	The weapon tech finishes strapping down the plasma cannons, and looks up to see another Remnant approaching. He gives the new Remnant a respectful dip of his head that almost seems like a bow before turning to you and chanting, "Ah, Captain <last>, have you met Tali? She is the engineering prefect here on Viminal. She asked me to let her know when or if you managed to procure the new tech for me."`
-			`	"Well met, Newcomer among the Remnant," trills the prefect. "Fresh blood amongst us sets songs in motion that have long been in Caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
+			`As <ship> settles onto the pad closest to the research facility, you can see the weapons specialist checking over a large cannon on a platform beneath a nearby Albatross. When he sees you starting to unload the two Plasma Cannons, he snaps the casing closed and gestures to someone out of sight. Within moments both him and an empty flatbed are there to pick up the weapons.`
+			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These Plasma Cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
+			`	The weapon technician finishes strapping down the Plasma Cannons, and looks up to see another Remnant approaching. He gives the new Remnant a respectful dip of his head that almost seems like a bow before turning to you and chanting, "Ah, Captain <last>, have you met Tali? She is the engineering prefect here on Viminal. She asked me to let her know when or if you managed to procure the new tech for me."`
+			`	Tali steps forward to face you. "Well met, newcomer among the Remnant," she trills. "Fresh blood amongst us sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
 			
 mission "Remnant: Return the Samples"
 	name "Return the Samples"
@@ -709,7 +708,7 @@ mission "Remnant: Return the Samples"
 		random < 50
 	on offer
 		conversation
-			`As you are walking through the spaceport, the researcher you previously assisted with the studies on the Void Sprites approaches you in a hustle. "We have made some new discoveries!" he exclaims in a trill. "Some of the samples that we took all those years ago are actually eggs of some kind. So the Archon must view our previous research as being disruptive to the Void Sprites' lifecycles."`
+			`As you are walking through the spaceport, the researcher you previously assisted with the studies on the void sprites approaches you in a hustle. "We have made some new discoveries!" he exclaims in a trill. "Some of the samples that we took all those years ago are actually eggs of some kind. So the Archon must view our previous research as being disruptive to the void sprites' lifecycles."`
 			`	"We have been storing these eggs in a cryogenic stasis tank, so they should still be viable and intact. Well, most of them, anyway." His notes trail off on a mournful tone.`
 			`	"Could you return some of them to Nasqueron? According to our logs, they were found floating in the lower levels of the atmosphere, where their natural buoyancy should keep them afloat."`
 			choice
@@ -727,14 +726,14 @@ mission "Remnant: Return the Samples"
 	on stopover
 		conversation
 			`Once again you have successfully dodged the Archon to land on Nasqueron. Somehow, knowing it was going to be there was both better and worse than the surprise of the first time.`
-			`	As <ship> sinks through the cloud layers, you gently activate the repulsors to slow your descent to avoid startling the Void Sprites. After what seems like an eternity, you notice a few nearby sprites descending as well, and you match velocity with them, slowing as you reach the altitude listed in the log.`
+			`	As <ship> sinks through the cloud layers, you gently activate the repulsors to slow your descent to avoid startling the void sprites. After what seems like an eternity, you notice a few nearby sprites descending as well, and you match velocity with them, slowing as you reach the altitude listed in the log.`
 			`	Setting the ship on auto-pilot, you head back and suit-up in something that looks more reminiscent of the old deep-sea diving suits than anything carried on a modern ship. Readying the eggs in the cargo hold, you equalize pressure in the main cargo hold to the swirling clouds outside, and open the cargo bay doors. As predicted, at this pressure level, the eggs are almost weightless, and are fairly easy to carry to the door of the ship and release.`	
-			`	By the time you finish releasing the eggs back into the clouds, several Void Sprites have converged on your ship and appear to be herding the eggs away from you with gentle buffets of their wings. You take a moment to appreciate the alien beauty of these creatures before closing the hatch and purging the ship with fresh air.`
+			`	By the time you finish releasing the eggs back into the clouds, several void sprites have converged on your ship and appear to be herding the eggs away from you with gentle buffets of their wings. You take a moment to appreciate the alien beauty of these creatures before closing the hatch and purging the ship with fresh air.`
 	on complete
 		"reputation:  Drak " = 1
 		conversation
 			`Your return trip to Aventine is just as exciting, dodging the Archon on the way out of the system.`
-			`	Back on the ground, you report on how the release went. The researcher is pleased to hear that the Void Sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
+			`	Back on the ground, you report on how the release went. The researcher is pleased to hear that the void sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
 
 mission "Remnant: Return the Samples 2"
 	name "Return the Samples 2"
@@ -823,7 +822,7 @@ mission "Remnant: Learning Sign 1"
 			`The trip to Viminal is quiet - almost no talking or singing of any kind as it is just about entirely reliant on interposing signs and pantomiming actions. Slowly you start picking up some of the easier nouns and verbs.`
 			`	As you descend through the atmosphere, you do some quick hand stretches to work the stiffness out of your fingers and rehearse some of the more common phrases. As soon as <ship> is parked, you exit and look around. Approaching a dockhand who doesn't appear to be busy, you carefully sign, "Can you direct me to the port director?" He looks at you curiously for a moment and replies with exaggerated slowness. You thank him and head towards the spaceport following his directions.`
 
-			
+
 mission "Remnant: Learning Sign 2"
 	name "Learning Remnant Sign"
 	description `Return to Caelian to finish your first class of sign language.`
@@ -869,7 +868,12 @@ mission "Remnant: Salvage 1"
 			has "Remnant: Heavy Laser: done"
 	on offer
 		conversation
-			`As you step out into the icy chill of Viminal you get a comlink message from Tali asking if you could meet her in the cafeteria. Replying that you can, you make your way through the crowds and find an empty table. Moments later Tali appears and grabs two trays from the dispenser before heading towards you. She settles down in the opposite chair with a look of exhaustion.`
+			`As you step out into the icy chill of Viminal you get a comlink message from Tali, the Engineering Prefect, asking if you could meet her in the cafeteria.`
+			choice
+				`	(Decline)`
+					defer
+				`	(Accept her invitation)`
+			Replying that you can, you make your way through the crowds and find an empty table. Moments later Tali appears and grabs two trays from the dispenser before heading towards you. She settles down in the opposite chair with a look of exhaustion.`
 			`	"It is good to see you again, <first>," she sings softly. When you sign a reply she sits up and smiles. "My, you are a quick learner," she signs. "Great, this is much faster."`
 			`	"I haven't fully..." (She makes a sign that you don't understand, but seems similar to the signs for "break" and "understand".) "...the technology you retrieved for us, but we should be ready to produce them soon. In the meantime, though, they are showing us that humanity has made significant progress since we departed. Could you help us catch up with what has happened out there?"`
 			choice
@@ -1055,13 +1059,13 @@ mission "Remnant: Salvage 5"
 	
 	on complete
 		payment 50000
-		dialog `On Caelian, you are able to find the appropriate research warehouse just off the main landing pad. After a few minutes, a lab tech disentangles herself from a project and brings a wagon and camel team out to the ship to unload the salvage. It strikes you as a bit incongruous that a lab tech is using a graviton repulsion lifter to load cargo from your ship into a wagon pulled by a camel. "If you can, I should have some things to send back to Tali if you could meet me in the cafeteria this afternoon."`
+		dialog `On Caelian, you are able to find the appropriate research warehouse just off the main landing pad. After a few minutes, a lab technician disentangles herself from a project and brings a wagon and camel team out to the ship to unload the salvage. It strikes you as a bit incongruous that a lab technician is using a graviton repulsion lifter to load cargo from your ship into a wagon pulled by a camel. "If you can, I should have some things to send back to Tali if you could meet me in the cafeteria this afternoon."`
 
 mission "Remnant: Salvage 6"
 	name "Transport outfits to Tali"
 	description `Deliver some parts to Viminal.`
 	cargo "Ship parts" 20
-	blocked `The tech you delivered Tali's salvaged parts to would like you to take some finished parts back to Tali, but you will need 20 tons of space to do so.`
+	blocked `The technician you delivered Tali's salvaged parts to would like you to take some finished parts back to Tali, but you will need 20 tons of space to do so.`
 	source "Caelian"
 	destination "Viminal"
 	to offer
@@ -1069,7 +1073,7 @@ mission "Remnant: Salvage 6"
 	on offer
 		event "Remnant Salvage Available"
 		conversation
-			`You spend the next few hours idly wandering around the spaceport, checking in to the cafeteria now and then waiting for the tech to show up. Virtually all the exposed structures around the spaceport look alien to you, composed of strange arcs and curves made of a dark iridescent substance you can't identify. Older areas are entirely subterranean, and usually still have blast doors and racks of camouflage netting prepped and ready to use. Finally you spot the laboratory technician entering the cafeteria, and she approaches you.`
+			`You spend the next few hours idly wandering around the spaceport, checking in to the cafeteria now and then waiting for the technician to show up. Virtually all the exposed structures around the spaceport look alien to you, composed of strange arcs and curves made of a dark iridescent substance you can't identify. Older areas are entirely subterranean, and usually still have blast doors and racks of camouflage netting prepped and ready to use. Finally you spot the laboratory technician entering the cafeteria, and she approaches you.`
 			`	"Thank you for waiting. I have a shipment of parts ready for Tali, and with the recent increase in attacks she needs them sooner rather than later. Could you take them to her?"`
 			choice
 				`	"Yes, I can."`
@@ -1089,7 +1093,7 @@ mission "Remnant: Salvage 6"
 			`	"Everything in here we have either learned how to duplicate in its current form, or have salvaged in sufficient quantities that we might as well be manufacturing it."`
 			`	She nods at a rack of Korath Heat Shunts while she explains, then turns back to you.`
 			`	"Of course the really advanced and rare stuff is still going to the labs first, and won't be available until we have learned all we can from it." She looks around proudly. "We don't have the industrial capacity or the numbers of researchers to keep up with the Alphas, the Korath, or whoever else might be out there. But we are very good at figuring out what others have built and learning from it.`
-			`	Any salvage or unrecognized technology gets scanned in our quarantine area for threats, then looked over to figure out if there is anything new in it. If there is something new, it is shipped to a lab for our researchers to dissect. Anything we have already figured out ends up in here, where Remnant captains are welcome to use it as they see fit."`
+			`	"Any salvage or unrecognized technology gets scanned in our quarantine area for threats, then looked over to figure out if there is anything new in it. If there is something new, it is shipped to a lab for our researchers to dissect. Anything we have already figured out ends up in here, where a select few captains are welcome to use it as they see fit."`
 			choice
 				`	"Threats?"`
 					goto threats
@@ -1097,9 +1101,9 @@ mission "Remnant: Salvage 6"
 			`	"Yes, it is, isn't it? So many new things out there to discover and learn about.`
 				goto end
 			label threats
-			`	"Yes, sometimes salvage that is brought in is dangerous. System Cores come with fleets of micro-bots, for instance. If they aren't de-activated properly, they keep trying to rebuild their surroundings in the form of the last ship they were configured to serve. And while it hasn't happened yet, we are worried that someday we might run into someone who builds traps into their equipment, or uses nanobots that could run amok. We haven't seen any of that yet, but our science-fiction stories are filled with tales of nanotech apocalypses and things like that.`
+			`	"Yes, sometimes salvage that is brought in is dangerous. System Cores come with fleets of micro-bots, for instance. If they aren't de-activated properly, they keep trying to rebuild their surroundings in the form of the last ship they were configured to serve. And while it hasn't happened yet, we are worried that someday we might run into someone who builds traps into their equipment, or uses nanobots that have run amok. We haven't seen any of that yet, but our science-fiction stories are filled with tales of nanotech apocalypses and things like that.`
 			label end
-			`	Well, I need to get back to work. That last battle put us behind schedule on our repairs. Have a good day!" With a final flourish that you think is the equivalent of an exclamation mark, Tali strides out of the outfitters, heading towards another landing bay.`
+			`	"Well, I need to get back to work. That last battle put us behind schedule on our repairs. Have a good day!" With a final flourish that you think is the equivalent of an exclamation mark, Tali strides out of the outfitters, heading towards another landing bay.`
 
 event "Remnant Salvage Available"
 	outfitter "remnant"
@@ -1120,27 +1124,28 @@ event "Remnant Salvage Available"
 
 mission "Remnant: Expanded Horizons Quarg 1"
 	name "Visiting the Quarg"
-	description "Take Remnant researchers to see some Quarg."
+	description "Take Remnant researchers to <destination> to see some Quarg."
 	minor
 	passengers 3
-	blocked "This mission requires bunks for three passengers."
 	source
 		government "Remnant"
 	destination "Wayfarer"
 	to offer
 		has "Remnant: Learning Sign 2: done"
+		has "Remnant: Salvage 1: done"
 		has "First Contact: Quarg: offered"
 		random < 40
 	on offer
 		conversation
 			`As you relax in the cafeteria on <planet> you are approached by a young Remnant. Judging by the hand-held sensors and tools hanging off her belt, you suppose she is a researcher or an engineer.`
 			`	"Hello Captain <last>. My name is Dawn, and I have been spending the past few days skimming the archive you retrieved. I wanted to ask you a few questions. May I?"`
+			`	She slides into the chair opposite you without waiting for your reply, and pulls out a datapad. "Firstly, our histories mention how humanity met a race called the 'Quarg' and had some ongoing dialogs with them, but not much beyond that. Now here in this history that you brought us, it says that humanity has started exchanging technology with them! Is this true?" She looks at you intently. You sign negatively, and she dejectedly continues. "Could you explain about them, then?" You reply that the Quarg have allowed humanity to live near them, and that the Quarg are usually willing to answer questions, including scientific ones. You continue, elaborating that while the Quarg don't seem to mind having an innovative shipyard studying them as best it can, they don't actually share their technology with anyone.`
+			`	After several hours of telling her about meeting the Quarg and visiting their world it finally occurs to you that it would be easy enough to take her to visit the Tarazed system.`
 			choice
-				`"Sure, pull up a chair."`
-				`"I'm not interested."`
+				`	(Don't offer)`
 					decline
-			`	She quickly slides into the chair opposite you and pulls out a datapad. "Firstly, our histories mention how humanity met a race called the 'Quarg' and had some ongoing dialogs with them, but not much beyond that. Now here in this history that you brought us, it says that humanity has started exchanging technology with them! Is this true?" She looks at you intently. You sign negatively, and she dejectedly continues. "Could you explain about them, then?" You reply that the Quarg have allowed humanity to live near them, and that the Quarg are usually willing to answer questions, including scientific ones. You continue, elaborating that while the Quarg don't seem to mind having an innovative shipyard studying them as best it can, they don't actually share their technology with anyone.`
-			`	After several hours of telling her about meeting the Quarg and visiting their world it finally dawns on you that it would be easy enough to take her to visit the Tarazed system. You offer to take her and a couple of her colleagues. She eagerly accepts, although she expresses a preference for landing on the human world, so they can observe the Quarg ships from a distance, as they would rather not draw any attention to themselves. She runs out of the cafeteria after telling you they will meet you at your ship in half an hour.`
+				`	(Offer to take her there)`
+			`	 You offer to take her and a couple of her colleagues. She eagerly accepts, although she expresses a preference for landing on the human world, so they can observe the Quarg ships from a distance, as they would rather not draw any attention to themselves. She runs out of the cafeteria after telling you they will meet you at your ship in half an hour.`
 				accept
 	on complete
 		payment 50000
@@ -1182,13 +1187,13 @@ mission "Remnant: Expanded Horizons Quarg 2"
 		government Quarg
 		personality staying uninterested
 		fleet Quarg
-		conversation
-			`	Dawn and her compatriots eagerly pore over the readouts as they come in, then ask if you could land again to compare their scans to ones taken on the ground.`
+		dialog
+			`Dawn and her compatriots eagerly pore over the readouts as they come in, then ask if you could land again to compare their scans to ones taken on the ground.`
 
 	on complete
 		payment 50000
 		conversation
-			`You breath a sigh of relief once you are back on the ground without a reaction from the Quarg. You were a touch worried they might take exception to being scanned, but they seem to consider it par for the course for this system filled with human engineers.`
+			`Despite your reassurances that the Quarg don't mind being scanned, you breath a sigh of relief once you are back on the ground without a reaction from them. Perhaps it was an unreasonable worry, but with a trio of secretive Remnant onboard, you can't help but feel a bit nervous about potentially exposing them to the Quarg.`
 			`	Dawn does some follow-up scans of idle Quarg ships, and they take some time to make sure all their pictures are well focused and accurate. They let you know that they will meet you back in the spaceport bar.`
 
 mission "Remnant: Expanded Horizons Quarg 3"
@@ -1203,7 +1208,7 @@ mission "Remnant: Expanded Horizons Quarg 3"
 		has "Remnant: Expanded Horizons Quarg 2: done"
 	on offer
 		conversation
-			`Back in the spaceport bar you wait around for a couple hours. Just when you were about to go find them, the trio walk in looking a tad tired but otherwise unreadable.`
+			`Back in the spaceport bar you wait around for a couple hours. Just when you were about to go find them, the trio walk in looking like they had spent all day on the move, but otherwise unreadable.`
 			`	"OK, I think we are ready to go. Can you take us to <planet>?"`
 			choice
 				`	Yes`
@@ -1215,104 +1220,7 @@ mission "Remnant: Expanded Horizons Quarg 3"
 		payment 50000
 		conversation
 			`Once you are back in the privacy of <ship>, the stony reserve fades to cheerfulness as the trio are a blur of motion as they chatter back and forth with their signs. Apparently this will be one of the biggest boosts to their research since the first time they salvaged the gear off a Korath raider.`
-			`	They eventually slow down their signs a bit and explain that up until the time the Remnant left human space, the Quarg had been reluctant to let anyone conduct detailed scans of their ships, let alone the close contact the engineers on Tarazed seem to enjoy. One of Dawn's fellow researchers continues with the explanation.`
+			`	They eventually slow down their signs a bit and explain that up until the time the Remnant left human space, human scanners had been unable to penetrate the outer layers of Quarg ships. One of Dawn's fellow researchers continues with the explanation.`
 			`	"Our historical records just have a few pictures and videos of Quarg ships, along with a basic scan that doesn't provide more than the general outline of the ship. These scans," he says while tapping the databanks, "actually picked up detailed structural layouts and even identified a number of key components. It isn't nearly enough information to be able to duplicate them, but it is enough that we can start trying to figure out how they work.`
 			`	Upon arriving at <planet> they quickly thank you, and run back to their offices to finish prepping their material to publish and distribute.`
 
-mission "Remnant: Follow-up on Terminus Researchers"
-	name "Check up on Wormhole Researchers"
-	description "Return to Bounty to check up on a group of wormhole researchers you met some time ago."
-	minor
-	source
-		government Remnant
-	destination Bounty
-	to offer
-		has "Remnant: Learning Sign 2: done"
-		has "Terminus exploration: done"
-		random < 50
-	on offer
-		conversation
-			`Looking around at the Remnant spaceport, it suddenly strikes you how amazing this is. You never would have imagined that you would end up here back when you earned your pilot's license. It seems so long ago that your biggest concern was deciding whether to pay off your loan by ferrying cargo, doing courier jobs, or escorting merchants. (and on your darker days - by being a pirate).`
-			`	Thinking back, it suddenly occurs to you that you helped retrieve a science drone for some researchers on Bounty - researchers who were studying the wormhole in Terminus. Research like that might be of interest to the Remnant, seeing as it could open the door to research vessels venturing into the Ember Wastes. It would only be a matter of time until someone figures out how to use the key stones - either by luck or by research, and then the Remnant's secrecy would vanish.`
-			choice
-				`	(Forget about it.)`
-					decline
-				`	(Find a prefect.)`
-			`	For lack of a better place to go, you stop by the information desk where you picked up the sign language course. You tell the attendant that you have something potentially important - but non-urgent - to discuss in regards to Remnant security. They tap a few buttons, then give you directions down a hallway. You quickly find yourself in an armory where several remnant guards are in the process of cleaning their weapons. One stands up and comes over to you.`
-			`	"Greetings Captain, I am Prefect Reegar. I was told you had some information that could be important?"`
-			`	He takes a seat on a bench on the far side of the room from the other Remnant, and gestures for you to take a seat with him.`
-			`	You give him some background about the current state of Human and Hai understanding about the wormholes - or the lack thereof - then explain how you met a team of researchers who were using drones to study the wormhole exit in the Terminus system. He quickly picks up on the potential threat if someone figures out the key to using them, especially since you have demonstrated that it only takes one curious human to figure it out.`
-			`	Thinking carefully, he asks, "It is clear that we need to keep an eye on this situation. You know more about the rest of the galaxy than we do, so could you find them and see how much progress they have made?"`
-			choice
-				`	"I'd prefer not to."`
-					decline
-				`	"I'd be happy to."`
-			`	"Excellent. See what you can find out about their research and results, but it would probably be wise to avoid making direct contact with them."`
-				accept
-	on complete
-		conversation
-			`Arriving on Bounty, you take a discreet look around the spaceport, but you don't find the researchers or any sign of them. It appears that they packed up and left since the last time you saw them. Time to look around for some info.`
-
-mission "Remnant: Follow-up on Terminus Researchers 2"
-	name "Check up on Terminus Researchers"
-	description "Tracking down the wormhole researchers."
-	source Bounty
-	destination
-		government Deep
-	to offer
-		has "Remnant: Follow-up on Terminus Researchers: done"
-	on offer
-		conversation
-			`A few hours of searching later, you find a lead: It seems that launching probes into the Terminus system isn't exactly a common activity, so their permits stand out from the rest. A helpful clerk in the spaceport office pulled up their application and found that they are listed as part of a university in the Deep, although it doesn't mention which planet their specific campus is on. A quick check of the directory lists a number of planets where they could be found.`
-			choice
-				`	(Stop investigating.)`
-					decline
-				`	(Continue the investigation)`
-				accept
-	on complete
-		conversation
-			`	Once you've landed on <planet> you look up the local university and pay it a visit. After thinking about it for a minute, you decide that probably the best source of information would be to visit the university library and ask one of the librarians for assistance locating research on wormholes. After some brief research, they return with a handful of research papers published over the past decade. They proudly note that two of the more recent papers were published here in the Deep, and transfer copies of each to you for free.`
-
-mission "Remnant: Follow-up on Terminus Researchers 3"
-	name "Check up on Terminus Researchers"
-	description "Returning with information on the wormhole researchers"
-	source
-		government Deep
-	destination
-		government Remnant
-	to offer
-		has "Remnant: Follow-up on Terminus Researchers 2: done"
-	on offer
-		conversation
-			`Back on board <ship>, you take a moment to flip through the papers.  You quickly realize that little beyond the summary is understandable to someone without a good theoretical understanding of physics. Even with your first-hand experience of wormholes, most of what they are discussing doesn't make much sense.`
-			`	All the academic stuff aside, the summary on the most recent paper confirms that the researchers are making progress: They have determined that the spatial anomaly in the Terminus system is in fact a wormhole with some kind of instability. They also speculate that it may be possible for a ship to artificially stabilize the wormhole enough for it to pass through unharmed.`
-			`	Prefect Reegar is definitely going to be interested in seeing this.`
-			accept
-	on complete
-		payment 2000000
-		conversation
-			`The trip back to the Ember Wastes is long, and it gave you plenty of opportunities to think about what this research could lead to. You also wondered about what the Remnant will do, as it seems obvious that their current isolation is about to fail.`
-			`	Reegar seems grimly optimistic on receiving your report "If this had happened without us being aware, it could have gone badly. Fortunately for us, you were in the right place at the right time, and have proven yourself loyal to us. So we are now forewarned and can use this time to plan and prepare for it. Perhaps re-establishing contact with the rest of humanity could even be to our benefit, but that will be for the council to decide."`
-			`	"Thank you, Captain. If you ever come across any other interesting information like this, don't hesitate to bring it to me."`
-
-mission "Remnant: Busy Stranger"
-	landing
-	invisible
-	to offer
-		has "Remnant: Return the Samples 2: done"
-		has "Remnant: Salvage 6: done"
-		has "Remnant: Expanded Horizons Quarg 3: done"
-	source
-		government "Remnant"
-	on offer
-		payment 2000000
-		log "The prefects have suggested that all the jobs currently available are done, but they are working on more."
-		conversation
-			`An elderly man approaches your ship and you recognize him as the prefect who gave you your license to purchase Remnant technology.`
-			`	"It seems that you have been very helpful to the Remnant, Captain <last> of <ship>. While we do not have any more jobs for you right now, hopefully we will soon."`
-			choice
-				`	"I'm honored. Thank you."`
-					decline
-				`	"Are you sure there's nothing more I can do?"`
-			`	"Yes, we are sure, but there might be more soon."`
-				decline

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -386,7 +386,7 @@ mission "Remnant: Void Sprites 1"
 				`	"What is your name?"`
 					goto name
 
-			`	"Don't worry," he says, "I will find you. You are our only visitor from the outside in many decades; when you land here, it quickly becomes known."`
+			`	"Don't worry," he says, "I will find you. You are our only visitor from the outside generations; when you land here, it quickly becomes known."`
 				accept
 	
 			label name
@@ -585,29 +585,29 @@ mission "Remnant: Heavy Laser"
 				`	"I'd rather not share that."`
 					decline
 			
-			`	"Really? Our records indicate that humanity had basic laser weapons when we left, but nothing that would be considered useful modern weapons." She pauses to look down at her scanner. "And yet our scans indicate that they are capable of significant power output."`
+			`	"Really? Our records indicate that humanity had primitive laser weapons at the time of the Exodus, but nothing that would be considered useful as weapons." She pauses to look down at her scanner. "And yet our scans indicate that they are capable of significant power output.`
 			`	Based on these scans, we may well be able to learn quite a bit from these weapons. Would you be able to acquire a pair of them for us? We could offer you very good compensation for doing so."`
 			choice
 				`	"Sure, I would be glad to accept that deal."`
 				`	"Sorry, I'm really not interested in helping Remnant research."`
 					decline
 
-			`	After a bit of haggling, she agrees to pay you one and a half million credits in exchange for a cargo of two "Heavy Lasers."`
+			`	After a bit of haggling, she agrees to pay you one and a half million credits in exchange for a cargo of two Heavy Lasers.`
 				accept
 	on complete
 		outfit "Heavy Laser" -2
 		payment 1500000
 		conversation
-			`As <ship> descends towards its assigned landing pad, you notice the weapons researcher mounting some kind of weapon on a platform aimed down a firing range. Jumping down from the stand, she pushes a button and a flash of light erupts from the muzzle, and the target downrange is cut in half. She flips a leaver and raises the barrel, and people rush out onto the range with tools and devices to examine the destruction.`
-			`	A freight platform is already waiting at the platform when you land, and about the time you get the cargo loaded the researcher shows up. She's dusty and looks a bit tired, but appears pleased with the results of her experiments. "Captain <first>, I see you have the lasers as we agreed." You aren't sure if Remnant rub their hands in eagerness, but she looks ready to do so.`
+			`As you land, a group of researchers mount some kind of weapon on a platform aimed down a firing range. The researcher that asked you for the Heavy Lasers presses a button from behind a thick barrier to activate the weapon. A flash of light erupts from the muzzle as the target downrange is cut in half. The barrel of the weapon raises into the air and the researchers rush out onto the range with tools and devices to examine the destruction.`
+			`	The researcher approaches you while the Heavy Lasers are being unloaded from your ship. She's dusty and looks a bit tired, but appears pleased with the results of her experiments. "Captain <first>, I see you have the lasers as we agreed." You aren't sure if Remnant rub their hands in eagerness, but she looks ready to do so.`
 			`	She taps her comm-link, and moments later another Remnant appears from the scaffolding around a nearby Starling. The researcher straightens up and switches to a more stately melody. "Captain <last>, this is Prefect Tali. She is our most experienced engineer for dealing with alien tech."`
-			`	"Greetings Captain. We appreciate your help in acquiring these samples. It looks like we are far behind the rest of humanity in some respects. We have a lot of work to do if we are to catch up with them."`
+			`	Tali steps forward and makes gesture that seems to be a kind of welcoming gesture. "Greetings Captain. We appreciate your help in acquiring these samples. It looks like we are far behind the rest of humanity in some respects. We have a lot of work to do if we are to catch up with them."`
 
 
 
 mission "Remnant: Catalytic Ramscoop"
 	name "Retrieve Ramscoops for the Remnant"
-	description "An engineer on <planet> has offered to pay you one and a half million credits in exchange for obtaining two Catalytic Ramscoops."
+	description "An engineer on <planet> has offered to pay you <payment> credits in exchange for obtaining two Catalytic Ramscoops."
 	minor
 	source Viminal
 	to offer
@@ -620,7 +620,7 @@ mission "Remnant: Catalytic Ramscoop"
 	on offer
 		require "Catalytic Ramscoop"
 		conversation
-			`As you are walking through the spaceport, a woman comes up to you and introduces herself as an engineer at one of the Remnant development labs. She pauses awkwardly before beginning to chant "As your ship is the only one we have seen in generations that has outfits from ancestral space, we are intrigued by it. Could we take a closer look?"`
+			`As you are walking through the spaceport, a woman comes up to you and introduces herself as an engineer at one of the Remnant development labs. She pauses awkwardly before beginning to chant. "As your ship is the only one we have seen in generations that has outfits from ancestral space, we are intrigued by it. Could we take a closer look?"`
 			choice
 				`	"Yes, you are welcome to examine it."`
 					goto deep

--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -51,7 +51,8 @@ effect "inhibitor impact"
 	"random velocity" 6
 	"velocity scale" -.05
 
-	
+
+
 outfit "Thrasher Cannon"
 	category "Guns"
 	licenses
@@ -89,6 +90,8 @@ effect "thrasher impact"
 	"random velocity" 3
 	"velocity scale" -.1
 
+
+
 outfit "Thrasher Turret"
 	category "Turrets"
 	licenses
@@ -119,6 +122,8 @@ outfit "Thrasher Turret"
 		"shield damage" 38
 		"hull damage" 46
 	description "This turret mounts four Thrasher Cannons on a single rotating base. The resulting weapon deals a very satisfying amount of damage when fired from close range, especially against a slow-moving target."
+
+
 
 outfit "Point Defense Turret"
 	category "Turrets"
@@ -163,6 +168,7 @@ effect "point defense die"
 		"no repeat"
 	lifetime 15
 	"velocity scale" .2
+
 
 
 outfit "EMP Torpedo"
@@ -248,6 +254,7 @@ effect "emp spark"
 	"random frame rate" 6
 	"random velocity" 7
 	"velocity scale" 0.1
+
 
 
 # Systems:
@@ -350,6 +357,7 @@ outfit "Scanner Software"
 	"outfit scan speed" 1
 	"tactical scan power" 24
 	description "The Remnant are too few in number to support extensive ground-breaking research in all areas of technology, so they prefer to focus their efforts on a few areas of importance. To make up the deficiency in other areas, the Remnant rely on salvaging and reverse engineering technology from those around them. This software module is a key part of this effort, as it allows any ship the capacity to do detailed scans to determine what they want to target. Its range is shorter than that of dedicated scanning equipment, but it means every Remnant ship can be on the lookout for new technology."
+
 
 
 # Engines:

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -55,7 +55,7 @@ ship "Starling"
 		"Forge-Class Steering"
 		"Crucible-Class Steering"
 		"Hyperdrive"
-	
+
 	engine -16 82 0.7
 	engine 16 82 0.7
 	engine 0 90 1
@@ -76,13 +76,13 @@ ship "Starling" "Starling (Heavy)"
 	outfits
 		"Thrasher Cannon" 5
 		"Point Defense Turret"
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 10
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
@@ -92,18 +92,18 @@ ship "Starling" "Starling (Sniper)"
 		"EMP Torpedo Bay"
 		"Inhibitor Cannon" 4
 		"EMP Torpedo" 9
-		
+
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
 		"Scanner Software"
 		"Tuning Rifle" 9
-		
+
 		"Forge-Class Thruster"
 		"Smelter-Class Steering"
 		"Hyperdrive"
-	
+
 	gun "EMP Torpedo Bay"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
@@ -114,18 +114,18 @@ ship "Starling" "Starling (Hunter)"
 	outfits
 		"Inhibitor Cannon" 2
 		"Thrasher Turret"
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Emergency Ramscoop"
 		"Scanner Software"
 		"Tuning Rifle" 11
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
-	
+
 	gun
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
@@ -136,25 +136,26 @@ ship "Starling" "Starling (Thrasher)"
 	outfits
 		"Thrasher Cannon" 3
 		"Thrasher Turret"
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Quantum Key Stone"
 		"Scanner Software"
 		"Tuning Rifle" 8
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
-	
+
 	gun "Thrasher Cannon"
 	gun "Thrasher Cannon"
 	gun "Thrasher Cannon"
 	gun
 	gun
 
-	
+
+
 ship "Gull"
 	sprite "ship/gull"
 	thumbnail "thumbnail/gull"
@@ -191,18 +192,18 @@ ship "Gull"
 	outfits
 		"Inhibitor Cannon" 1
 		"Point Defense Turret"
-		
+
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Emergency Ramscoop" 2
 		"Quantum Key Stone"
 		"Scanner Software"
 		"Tuning Rifle" 3
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
-	
+
 	engine -12 70 0.7
 	engine 12 70 0.7
 	engine 0 78 1
@@ -222,13 +223,13 @@ ship "Gull" "Gull (Heavy)"
 	outfits
 		"Thrasher Cannon" 3
 		"Thrasher Turret"
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 4
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
@@ -237,13 +238,13 @@ ship "Gull" "Gull (Sniper)"
 	outfits
 		"Inhibitor Cannon" 3
 		"Thrasher Turret"
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 4
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
@@ -254,13 +255,13 @@ ship "Gull" "Gull (Support)"
 		"Inhibitor Cannon" 2
 		"Point Defense Turret"
 		"EMP Torpedo" 5
-		
+
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 3
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
@@ -268,12 +269,12 @@ ship "Gull" "Gull (Support)"
 ship "Gull" "Gull (Cargo)"
 	outfits
 		"Cargo Expansion" 4
-		
+
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 3
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
@@ -281,15 +282,16 @@ ship "Gull" "Gull (Cargo)"
 ship "Gull" "Gull (Bunks)"
 	outfits
 		"Bunk Room" 4
-		
+
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Scanner Software"
 		"Tuning Rifle" 3
-		
+
 		"Forge-Class Thruster"
 		"Forge-Class Steering"
 		"Hyperdrive"
+
 
 
 ship "Albatross"
@@ -328,18 +330,18 @@ ship "Albatross"
 		"Inhibitor Cannon" 6
 		"Thrasher Turret" 2
 		"Point Defense Turret"
-		
+
 		"Aeon Cell"
 		"Epoch Cell"
 		"Crystal Capacitor"
 		"Thermoelectric Cooler" 2
 		"Quantum Key Stone"
 		"Scanner Software"
-		
+
 		"Smelter-Class Thruster"
 		"Smelter-Class Steering"
 		"Hyperdrive"
-	
+
 	engine -28 155 .8
 	engine 28 155 .8
 	engine 0 184 .9
@@ -368,7 +370,7 @@ ship "Albatross" "Albatross (Sniper)"
 		"EMP Torpedo Bay" 2
 		"Point Defense Turret" 3
 		"EMP Torpedo" 18
-		
+
 		"Aeon Cell"
 		"Epoch Cell"
 		"Crystal Capacitor"
@@ -376,13 +378,13 @@ ship "Albatross" "Albatross (Sniper)"
 		"Quantum Key Stone"
 		"Scanner Software"
 		"Tuning Rifle" 57
-		
+
 		"Forge-Class Thruster"
 		"Crucible-Class Thruster"
 		"Smelter-Class Steering"
 		"Forge-Class Steering"
 		"Hyperdrive"
-	
+
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
@@ -390,7 +392,7 @@ ship "Albatross" "Albatross (Sniper)"
 	gun "Inhibitor Cannon"
 	gun "EMP Torpedo Bay"
 	gun "EMP Torpedo Bay"
-	
+
 	turret "Point Defense Turret"
 	turret "Point Defense Turret"
 	turret
@@ -401,7 +403,7 @@ ship "Albatross" "Albatross (Turret)"
 	outfits
 		"Thrasher Turret" 4
 		"Point Defense Turret"
-		
+
 		"Aeon Cell"
 		"Epoch Cell"
 		"Millennium Cell"
@@ -410,11 +412,11 @@ ship "Albatross" "Albatross (Turret)"
 		"Outfits Expansion" 2
 		"Scanner Software"
 		"Tuning Rifle" 49
-		
+
 		"Smelter-Class Thruster"
 		"Smelter-Class Steering"
 		"Hyperdrive"
-	
+
 	turret "Thrasher Turret"
 	turret "Thrasher Turret"
 	turret "Thrasher Turret"
@@ -426,7 +428,7 @@ ship "Albatross" "Albatross (Heavy)"
 		"Inhibitor Cannon" 3
 		"Thrasher Cannon" 4
 		"Thrasher Turret" 3
-		
+
 		"Aeon Cell"
 		"Epoch Cell"
 		"Millennium Cell"
@@ -435,13 +437,13 @@ ship "Albatross" "Albatross (Heavy)"
 		"Outfits Expansion" 4
 		"Scanner Software"
 		"Tuning Rifle" 65
-		
+
 		"Forge-Class Thruster"
 		"Crucible-Class Thruster"
 		"Smelter-Class Steering"
 		"Forge-Class Steering"
 		"Hyperdrive"
-	
+
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
 	gun "Inhibitor Cannon"
@@ -454,6 +456,7 @@ ship "Albatross" "Albatross (Heavy)"
 	turret
 	turret
 	turret "Thrasher Turret"
+
 
 
 ship "Gascraft"
@@ -485,20 +488,21 @@ ship "Gascraft"
 		"outfit scan speed" 1
 		"tactical scan power" 50
 		"atmosphere scan" 100
-		
+
 	outfits
 		"Millennium Cell"
 		"Emergency Ramscoop"
 		"Quantum Key Stone"
-		
+
 		"Crucible-Class Thruster"
 		"Crucible-Class Steering"
 		"Hyperdrive"
-	
+
 	engine 0 30
 	explode "tiny explosion" 8
 	explode "small explosion" 7
 	description "Centuries ago, the Remnant built these ships in order to explore the upper atmosphere of nearby gas giants. The Archons took issue with the Remnant's research methods, and the studies were unable to be completed. The remaining gascraft have been gathering dust in storage for centuries while the Remnant waits to see if the anger of the Archons will subside."
+
 
 
 ship "Pelican"


### PR DESCRIPTION
Fair number of changes to Remnant Missions, Outfits, and Ships.

Some white space corrections throughout, and a fair number of content changes for Amazinite.

Of note:
- The Terminus Researcher missions have been removed pending further discussion with Amazinite after his Bactrian campaign missions are merged.
- The Busy Stranger mission has been removed.
- The three retrieval missions are now mutually exclusive.