### PR TITLE
Removing pointless choice

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -1210,11 +1210,6 @@ mission "Remnant: Expanded Horizons Quarg 3"
 		conversation
 			`Back in the spaceport bar you wait around for a couple hours. Just when you were about to go find them, the trio walk in looking like they had spent all day on the move, but otherwise unreadable.`
 			`	"OK, I think we are ready to go. Can you take us to <planet>?"`
-			choice
-				`	Yes`
-				`	Not yet`
-					defer
-			`	"Great. We will be waiting on your ship."`
 				accept
 	on complete
 		payment 50000


### PR DESCRIPTION
Removing a pointless choice in Remnant: Expanded Horizons Quarg 3. (the player doesn't need a choice in taking the Remnant researchers home.)