### PR TITLE
Fixing a duplicate name and making white space more consistent.

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -75,6 +75,8 @@ event "ember waste label"
 	galaxy "label waste"
 		sprite label/waste
 
+
+
 mission "Remnant: Second Contact"
 	landing
 	invisible
@@ -139,6 +141,7 @@ mission "Remnant: Second Contact"
 			`	When you return to your ship, you do a search on videos of historical dialects of human sign language. None of them bear even a passing resemblance to the language of these people who call themselves the Remnant.`
 
 
+
 mission "Remnant: Defense 1"
 	source "Caelian"
 	name "Defend <planet>"
@@ -173,6 +176,7 @@ mission "Remnant: Defense 1"
 
 event "remnant defense timer"
 	clear "Remnant defense delay"
+
 
 
 mission "Remnant: Defense 2"
@@ -223,6 +227,8 @@ mission "Remnant: Defense 2"
 		dialog `The same woman meets you when you land on <planet>. "Again, thank you," she says. "I will suggest to others that they might offer you similar bounty hunting jobs in the future." She pays you <payment>.`
 		log "Factions" "Remnant" `Recently, Korath ships have begun raiding Remnant worlds. The Remnant have decided not to try to discourage these raids, because they are a perfect opportunity to steal jump drives and other valuable alien technology from the Korath.`
 
+
+
 mission "Remnant: Bounty"
 	job
 	repeat
@@ -247,6 +253,8 @@ mission "Remnant: Bounty"
 	on complete
 		payment 200000
 		dialog "A Remnant military leader thanks you for hunting down the <npc>, and gives you the agreed-upon payment of <payment>."
+
+
 
 mission "Remnant: Defense 3"
 	landing
@@ -301,6 +309,8 @@ event "remnant: surveillance begin"
 event "remnant: surveillance end"
 	system "Parca"
 		add fleet "Korath Raid" 10000
+
+
 
 mission "Remnant: Key Stones"
 	name "Keystones"
@@ -561,6 +571,7 @@ mission "Remnant: Technology Available"
 				decline
 
 
+
 mission "Remnant: Heavy Laser"
 	name "Retrieve Heavy Lasers for the Remnant"
 	description "A Remnant engineer on <planet> has offered to pay you one and a half million credits in exchange for obtaining two Heavy Lasers."
@@ -650,6 +661,8 @@ mission "Remnant: Catalytic Ramscoop"
 			`You visit the local shipyard and eventually find the engineer busily repairing a damaged Starling. You inform her that you have brought a pair of "Catalytic Ramscoops" for her to study. She quickly tightens a couple more connectors and jumps down from her perch, gesturing at an assistant to transfer you the credits you were promised. "Thank you! Our maps of human space are old, and if they are still accurate, you traveled a very long way to bring these to us." Her chanting voice echoes off the starling above you with an interesting resonance.`
 			`	"Thank you for your help," she says. "If we can unlock the secrets of these scoops, it will give our ships greater range as they search for a safer refuge." As she picks up the remote control for the small loading truck with the two ramscoops she trills at you over her shoulder. "Oh, my name is Tali. I'll let you know what I find."`
 
+
+
 mission "Remnant: Plasma Cannons"
 	name "Retrieve Plasma Cannons for the Remnant"
 	description "An engineer on <planet>, a Remnant world, has offered to pay you 800'000 credits in exchange for obtaining two Plasma Cannons."
@@ -697,7 +710,9 @@ mission "Remnant: Plasma Cannons"
 			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These Plasma Cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
 			`	The weapon technician finishes strapping down the Plasma Cannons, and looks up to see another Remnant approaching. He gives the new Remnant a respectful dip of his head that almost seems like a bow before turning to you and chanting, "Ah, Captain <last>, have you met Tali? She is the engineering prefect here on Viminal. She asked me to let her know when or if you managed to procure the new tech for me."`
 			`	Tali steps forward to face you. "Well met, newcomer among the Remnant," she trills. "Fresh blood amongst us sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
-			
+
+
+
 mission "Remnant: Return the Samples"
 	name "Return the Samples"
 	description "A researcher on <planet>, has asked you to return some samples to Nasqueron."
@@ -734,6 +749,8 @@ mission "Remnant: Return the Samples"
 		conversation
 			`Your return trip to Aventine is just as exciting, dodging the Archon on the way out of the system.`
 			`	Back on the ground, you report on how the release went. The researcher is pleased to hear that the void sprites responded to their presence. "We will give them a few weeks, then try sending another ship to monitor them. Hopefully the Archon will be pacified by this. Meet me in the alien environments lab just off the spaceport if you are interested in pursuing this."`
+
+
 
 mission "Remnant: Return the Samples 2"
 	name "Return the Samples 2"
@@ -772,7 +789,8 @@ mission "Remnant: Return the Samples 2"
 		conversation
 			`Back on Aventine, you share the recording of the void sprite's behavior with Plume. "These Sprites demonstrate considerably more communication than we originally thought. And obviously they must have communicated what you did on Nasqueron. Interesting..." Plume's excited staccato exclamations trail off as he begins to make notes on a datapad he has on hand.`
 
-		
+
+
 mission "Remnant: Learning Sign 1"
 	name "Learning Remnant Sign"
 	description `Visit each of the Remnant worlds to find ways to learn their sign language.`
@@ -823,6 +841,7 @@ mission "Remnant: Learning Sign 1"
 			`	As you descend through the atmosphere, you do some quick hand stretches to work the stiffness out of your fingers and rehearse some of the more common phrases. As soon as <ship> is parked, you exit and look around. Approaching a dockhand who doesn't appear to be busy, you carefully sign, "Can you direct me to the port director?" He looks at you curiously for a moment and replies with exaggerated slowness. You thank him and head towards the spaceport following his directions.`
 
 
+
 mission "Remnant: Learning Sign 2"
 	name "Learning Remnant Sign"
 	description `Return to Caelian to finish your first class of sign language.`
@@ -851,6 +870,7 @@ mission "Remnant: Learning Sign 2"
 			`	You arrive at the Director's desk and offer to return the datapad to the Director, signing your thanks. She seems pleased at how much you have learned, and replies that you are welcome to keep it for as long as you need it.`
 			`	She pauses for a moment, then signs, "You are probably wondering about all the blood tests. Long ago it was decided that being infiltrated by Alpha agents was a big risk, and we couldn't depend on our interstellar network to remain secure. So we implemented a policy where the first time a Remnant is granted formal access to a new planet their purity and identity is verified. Thus even if someone hacked our networks to give themselves a clean identity, they would still be caught when they started working on a new planet. We also don't broadcast that requirement on our networks, simply enforce it locally. It isn't foolproof, but it adds an additional layer of safety."`
 			`	After you finish your conversation with her, you stroll off to look around the spaceport, enjoying the fact that you can now understand a bit of the conversations going on around you. It still takes quite a bit of effort, but it is a good start.`
+
 
 
 mission "Remnant: Salvage 1"
@@ -892,6 +912,8 @@ mission "Remnant: Salvage 1"
 			`	Before you have even taken the time to shutdown the engines Tali is halfway up the side of your ship securing a refueling hose and charging cable. As you reach for the comlink she scrambles up to the bridge windows and quickly rattles off a series of signs at you. All you can make out is "Keep...hot, incoming something!" Before you can frame a reply she has raced across your wing and leapt to the Albatross parked next to you.`
 			`	Looking around more carefully, you note that every ship in the port is idling with fuel lines still connected. If this were some Republic port the safety inspectors would be having a nightmare. One Starling is getting holes in its wings patched even as the crew appear to be running prep-for-flight checklists. It also looks like every ship has a guard. Something tells you that right now would be a bad time to take a walk around town.`
 
+
+
 mission "Remnant: Salvage 2"
 	landing
 	source "Viminal"
@@ -926,6 +948,8 @@ mission "Remnant: Salvage 2"
 			`As some ships maintain orbital sentry positions, most ships return to their berths. Mechanics are soon swarming over the ships, and what you suppose are ambulances are waiting at the ramps to collect the injured. Farther back, flatbed tractor units wait to pick up any salvage that has been collected.`
 			`	Eventually a tired but pleased-looking prefect stops by your ship. He starts chanting, "Do you understand our language, or do I need to sing?" He looks relieved when you reply that you can understand most of what is said so long as he signs slowly. "Thank you for your assistance during the raid. The sensors you placed on Parca picked up the fleet coming in and gave us sufficient warning to get everyone ready."`
 			`	He is silent for a moment, with the air of someone who is enjoying not having to run for the first time in a while. "Oh, Tali said that you might have some historical records for us?" You hand over the copy of the archive in response, telling him that is probably the best available. He thanks you and hands over a creditstick with 1.5M credits on it. After a little more conversation he hauls himself to his feet. "I'll make sure this gets where it needs to go. Thank you!"`
+
+
 
 mission "Remnant: Salvage 3"
 	source "Viminal"
@@ -964,6 +988,7 @@ event "Remnant Albatross"
 	shipyard "Remnant"
 		"Albatross"
 		"Pelican"
+
 
 
 mission "Remnant: Salvage 4"
@@ -1008,10 +1033,12 @@ mission "Remnant: Salvage 4"
 		payment 500000
 		dialog `Back in the spaceport, you are met by the prefect who thanks you for disabling it and hands you a credstick for <payment>. "Oh, and if you managed to plunder anything, don't forget to drop it off in the outfitters so the researchers can look at it.`
 
-mission "Remnant: Bounty"
+
+
+mission "Remnant: Lurker Bounty"
 	job
 	repeat
-	name "Remnant bounty"
+	name "Remnant lurker bounty"
 	description "Hunt down a Korath ship that is lurking in Remnant territory, then return to <planet> to receive your payment of <payment>."
 	source
 		government "Remnant"
@@ -1030,11 +1057,11 @@ mission "Remnant: Bounty"
 				"Korath Raider (Hyperdrive)"
 		dialog "You have destroyed the Korath ship. You can now return to <planet> to collect your payment."
 	on complete
-		payment 200000
+		payment 250000
 		dialog "A Remnant military leader thanks you for hunting down the Korath ship <npc>, and gives you the agreed-upon payment of <payment>."
 
-		
-		
+
+
 mission "Remnant: Salvage 5"
 	name "Salvage Delivery"
 	description `Deliver some high value salvage to Caelian.`
@@ -1060,6 +1087,8 @@ mission "Remnant: Salvage 5"
 	on complete
 		payment 50000
 		dialog `On Caelian, you are able to find the appropriate research warehouse just off the main landing pad. After a few minutes, a lab technician disentangles herself from a project and brings a wagon and camel team out to the ship to unload the salvage. It strikes you as a bit incongruous that a lab technician is using a graviton repulsion lifter to load cargo from your ship into a wagon pulled by a camel. "If you can, I should have some things to send back to Tali if you could meet me in the cafeteria this afternoon."`
+
+
 
 mission "Remnant: Salvage 6"
 	name "Transport outfits to Tali"
@@ -1120,7 +1149,8 @@ event "Remnant Salvage Available"
 		"Thruster (Comet Class)"
 		"Steering (Comet Class)"
 		"Korath Fire-Lance"
-	
+
+
 
 mission "Remnant: Expanded Horizons Quarg 1"
 	name "Visiting the Quarg"
@@ -1163,6 +1193,8 @@ mission "Remnant: Expanded Horizons Quarg 1"
 			label end
 			`	After an hour of browsing, the young remnant take off to browse the outfitters and agree to meet you back at the spaceport in an hour.`
 
+
+
 mission "Remnant: Expanded Horizons Quarg 2"
 	name "Quarg Scanning"
 	description "Perform an outfit scan on the Quarg ship <npc>, then land again on <destination>."
@@ -1195,6 +1227,8 @@ mission "Remnant: Expanded Horizons Quarg 2"
 		conversation
 			`Despite your reassurances that the Quarg don't mind being scanned, you breath a sigh of relief once you are back on the ground without a reaction from them. Perhaps it was an unreasonable worry, but with a trio of secretive Remnant onboard, you can't help but feel a bit nervous about potentially exposing them to the Quarg.`
 			`	Dawn does some follow-up scans of idle Quarg ships, and they take some time to make sure all their pictures are well focused and accurate. They let you know that they will meet you back in the spaceport bar.`
+
+
 
 mission "Remnant: Expanded Horizons Quarg 3"
 	name "Expanded Horizons Return"


### PR DESCRIPTION
- Fixing a duplicate mission name (two separate missions named "Remnant Bounty" (later one renamed to "Remnant Lurker Bounty",
- making mission white space consistent (3 white lines before each mission)