### PR TITLE
Plasma canon changes A

### DIFF
--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -730,7 +730,7 @@ mission "Remnant: Plasma Weapons"
 	on complete
 		outfit "Plasma Cannon" -2
 		payment 800000
-		log "People" "Tali" `As an engineering prefect, Tali is the foremost authority among the Remnant on salvaged technology and a senior leader in their reverse engineering program.`
+		
 		conversation
 			`As <ship> settles onto the pad closest to the research facility, you can see the weapons specialist checking over a large cannon on a platform beneath a nearby Albatross. When he sees you starting to unload the two plasma cannons, he snaps the casing closed and gestures to someone out of sight. Within moments both him and an empty flatbed are there to pick up the weapons.`
 			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These plasma cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
@@ -743,6 +743,22 @@ mission "Remnant: Plasma Weapons"
 			`	Tali steps forward to face you. "Well met once again, <first>," she trills. "Your fresh actions set songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
 			
 			`	Tali steps forward to face you. "Well met, newcomer among the Remnant," she trills. "Fresh blood amongst us sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
+
+
+
+mission "Remnant: Tali Log Entry"
+	name "Tali Log Entry"
+	source
+		"Remnant"
+	invisible
+	to offer
+		or
+			has "Remnant: Plasma Weapons: done"
+			has "Remnant: Catalytic Ramscoop: done"
+			has "Remnant: Heavy Laser: done"
+	on offer
+		log "People" "Tali" `As an engineering prefect, Tali is the foremost authority among the Remnant on salvaged technology and a senior leader in their reverse engineering program.`
+
 
 
 mission "Remnant: Return the Samples"

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -573,8 +573,6 @@ mission "Remnant: Heavy Laser"
 		has "Remnant: Technology Available: offered"
 		not "Remnant: Catalytic Ramscoop: active"
 		not "Remnant: Catalytic Ramscoop: done"
-		not "Remnant: Plasma Cannons: active"
-		not "Remnant: Plasma Cannons: done"
 		random < 50
 	on offer
 		require "Heavy Laser"
@@ -614,8 +612,6 @@ mission "Remnant: Catalytic Ramscoop"
 		government "Remnant"
 	to offer
 		has "Remnant: Technology Available: offered"
-		not "Remnant: Plasma Cannons: active"
-		not "Remnant: Plasma Cannons: done"
 		not "Remnant: Heavy Laser: active"
 		not "Remnant: Heavy Laser: done"
 		random < 50
@@ -699,7 +695,7 @@ mission "Remnant: Plasma Weapons"
 	on offer
 		require "Plasma Cannon"
 		conversation
-			`As you are browsing the spaceport shops, a man approaches you and introduces himself as a weapons specialist at one of the Remnant research facilities. He pauses hesitantly before beginning to chant: "When I watched your ship soar in, I noticed a weapon design that seemed familiar from our history. Would you permit me to examine it?"`
+			`As you are browsing the spaceport shops, a man approaches you and introduces himself as a weapons specialist at one of the Remnant research facilities. He pauses hesitantly before beginning to chant: "I was watching when your ship soared in to land, and I noticed a weapon design that seemed familiar from our history. Would you permit me to examine it?"`
 			choice
 				`	"Sure, you may examine it."`
 					goto examine
@@ -741,8 +737,11 @@ mission "Remnant: Plasma Weapons"
 			`	The weapon technician finishes strapping down the plasma cannons and looks up to see another Remnant approaching. He gives the new Remnant a respectful dip of his head that almost seems like a bow before turning to you and chanting, "Ah, Captain <last>, have you met Tali? She is the engineering prefect here on Viminal. She asked me to let her know when or if you managed to procure the new tech for me."`
 			branch
 				has "Remnant: Catalytic Ramscoop: done"
-			`	Tali steps forward to face you. "Well met once again, <first>," she trills. "Your fresh actions sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
-				
+			`	Tali steps forward to face you. "Well met once again, <first>," she trills. "Your fresh actions set songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
+			branch
+				has "Remnant: Heavy Laser: done"
+			`	Tali steps forward to face you. "Well met once again, <first>," she trills. "Your fresh actions set songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
+			
 			`	Tali steps forward to face you. "Well met, newcomer among the Remnant," she trills. "Fresh blood amongst us sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
 
 

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -656,45 +656,79 @@ mission "Remnant: Catalytic Ramscoop"
 
 
 
-mission "Remnant: Plasma Cannons"
-	name "Retrieve Plasma Cannons for the Remnant"
-	description "An engineer on <planet> has offered to pay you <payment> credits in exchange for obtaining two plasma cannons."
+mission "Remnant: Plasma Cannon Check"
+	name "Check to see if player has a Plasma Cannon"
 	minor
 	source
 		government "Remnant"
 	to offer
 		has "Remnant: Technology Available: offered"
-		not "Remnant: Catalytic Ramscoop: active"
-		not "Remnant: Catalytic Ramscoop: done"
-		not "Remnant: Heavy Laser: active"
-		not "Remnant: Heavy Laser: done"
+	invisible
+	on offer
+		require "Plasma Cannon"
+	to complete
+		has "Remnant: Plasma Weapons: offered"
+
+
+
+mission "Remnant: Plasma Turret Check"
+	name "Check to see if player has a Plasma Turret"
+	minor
+	source
+		government "Remnant"
+	to offer
+		has "Remnant: Technology Available: offered"
+	invisible
+	on offer
+		require "Plasma Turret"
+	to complete
+		has "Remnant: Plasma Weapons: offered"
+
+
+mission "Remnant: Plasma Weapons"
+	name "Retrieve Plasma Cannons for the Remnant"
+	description "An engineer on <planet> has offered to pay you <payment> in exchange for obtaining two plasma cannons."
+	source
+		government "Remnant"
+	to offer
+		has "Remnant: Technology Available: offered"
+		or
+			has "Remnant: Plasma Cannon Check: offered"
+			has "Remnant: Plasma Turret Check: offered"
 		random < 50
 	on offer
 		require "Plasma Cannon"
 		conversation
-			`As you are browsing the spaceport shops, a man approaches you and introduces himself as a weapons specialist at one of the Remnant research facilities. He pauses hesitantly before beginning to chant: "As your ship is the only one we have seen in generations that has weapons from human space, we are intrigued by it. Could we take a closer look?"`
+			`As you are browsing the spaceport shops, a man approaches you and introduces himself as a weapons specialist at one of the Remnant research facilities. He pauses hesitantly before beginning to chant: "When I watched your ship soar in, I noticed a weapon design that seemed familiar from our history. Would you permit me to examine it?"`
 			choice
-				`	"Yes, you are welcome to examine it."`
-					goto deep
-				`	"Yes, but don't touch anything."`
+				`	"Sure, you may examine it."`
+					goto examine
 				`	"No, stay away from my ship."`
 					decline
 
-			`	"Don't worry," he sings with a tinge of reproach. "I am a Remnant, not a Korath."`
-			`	He proceeds to methodically examine your ship from every angle on the ground, eventually focusing on your weapon ports and hardpoints. After examining the <ship> for quite some time, he walks over to you.`
-				goto more
-
-			label deep
-			`	He clips his harness to one of the overhead lifts, presses a button on the back of his gauntlet, and is promptly whisked up into the air. The lift appears designed to give engineers and technicians almost as much freedom as a zero-g environment by suspending them with just enough force to counteract gravity, so they can move around a ship with ease. Having completed a quick once-over he quickly gravitates to the weapon hardpoints. After examining the <ship> for quite some time, he calls down to you.`
-
-			label more
-			`	"I have never seen weapons designed to handle such a high heat output! Is this some kind of plasma based weapon?" he asks, gesturing at a plasma cannon. You nod, and he continues, "Intriguing. We have noticed that the Korath ships seem to run particularly hot, and have speculated that overheating them might be an effective means of disabling them. I would enjoy researching these a bit more. If you could acquire some for us you would be well compensated."`
+			label examine
+			`	He clips his harness to one of the overhead lifts, presses a button on the back of his gauntlet, and is promptly whisked up into the air. The lift appears designed to give engineers and technicians almost as much freedom as a zero-g environment by suspending them with just enough force to counteract gravity, so they can move around a ship with ease. He appears to have already identified the weapon hardpoints, and heads straight to them.`
+			`	"I have never seen weapons designed to handle such a high heat output! Is this some kind of plasma based weapon?" he asks, gesturing at it. You nod, and he continues, "Impressive. Our historical records mention that such weapons were just starting to be used by military forces at the time of our flight. Such a use for plasma had slipped from memory until we noticed that the Korath ships seem to run particularly hot. Our tacticians have speculated that overheating them might be an effective means of disabling them." He pauses, then chants again "I would enjoy researching these a bit more."`
+			branch
+				has "FW Plasma Testing 1B: done"
+			`	You recall that you helped Kraz Cybernetics test some experimental plasma turrets for the Free Worlds."`
+			choice
+				`	"I have some testing footage"`
+					goto kraz
+				`	(don't say anything)`
+					goto nothing
+			label kraz
+			`	"You do? Could I see it?" he asks eagerly. You pull up your scanner logs from the Kraz Cybernetics weapons tests and make a copy for him. "That's very helpful! If you could get a pair of plasma cannons to with the footage, you will be well compensated."`
+				goto decision
+			label nothing
+			`	"If you could acquire some plasma cannons for us you would be well compensated."`
+			label decision
 			choice
 				`	"Sure, I would be glad to work out a deal."`
 				`	"Sorry, I'm really not interested in helping Remnant research."`
 					decline
 
-			`	After a bit of negotiation, he agrees to pay you <payment> credits in exchange for a cargo of two plasma cannons.`
+			`	After a bit of negotiation, he agrees to pay you <payment> in exchange for a cargo of two plasma cannons.`
 				accept
 	
 	on complete
@@ -705,8 +739,11 @@ mission "Remnant: Plasma Cannons"
 			`As <ship> settles onto the pad closest to the research facility, you can see the weapons specialist checking over a large cannon on a platform beneath a nearby Albatross. When he sees you starting to unload the two plasma cannons, he snaps the casing closed and gestures to someone out of sight. Within moments both him and an empty flatbed are there to pick up the weapons.`
 			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These plasma cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
 			`	The weapon technician finishes strapping down the plasma cannons and looks up to see another Remnant approaching. He gives the new Remnant a respectful dip of his head that almost seems like a bow before turning to you and chanting, "Ah, Captain <last>, have you met Tali? She is the engineering prefect here on Viminal. She asked me to let her know when or if you managed to procure the new tech for me."`
+			branch
+				has "Remnant: Catalytic Ramscoop: done"
+			`	Tali steps forward to face you. "Well met once again, <first>," she trills. "Your fresh actions sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
+				
 			`	Tali steps forward to face you. "Well met, newcomer among the Remnant," she trills. "Fresh blood amongst us sets songs in motion that have long been in caesura. I have a few things to finish up right now, but I hope to work with you soon." She gives you a polite nod and heads back the way she came.`
-
 
 
 mission "Remnant: Return the Samples"

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -595,7 +595,6 @@ mission "Remnant: Heavy Laser"
 	on complete
 		outfit "Heavy Laser" -2
 		payment 1000000
-		log "People" "Tali" `As an engineering prefect, Tali is the foremost authority among the Remnant on salvaged technology and a senior leader in their reverse engineering program.`
 		conversation
 			`As you land, a group of researchers mount some kind of weapon on a platform aimed down a firing range. The researcher that asked you for the heavy lasers presses a button from behind a thick barrier to activate the weapon. A flash of light erupts from the muzzle as the target downrange is cut in half. The barrel of the weapon raises into the air and the researchers rush out onto the range with tools and devices to examine the destruction.`
 			`	The researcher approaches you while the heavy lasers are being unloaded from your ship. She's dusty, but appears pleased with the results of her experiments. "Captain <first>, I see you have the lasers as we agreed." You aren't sure if Remnant rub their hands in eagerness, but she looks ready to do so.`
@@ -645,7 +644,6 @@ mission "Remnant: Catalytic Ramscoop"
 	on complete
 		outfit "Catalytic Ramscoop" -2
 		payment 1500000
-		log "People" "Tali" `As an engineering prefect, Tali is the foremost authority among the Remnant on salvaged technology and a senior leader in their reverse engineering program.`
 		conversation
 			`You visit the local shipyard and eventually find the engineer busily repairing a damaged Starling. You inform her that you have brought a pair of catalytic ramscoops for her to study. She quickly tightens a couple more connectors and jumps down from her perch, gesturing at an assistant to transfer you the credits you were promised. "Thank you! Our maps of human space are old, and if they are still accurate, you traveled a very long way to bring these to us." Her chanting voice echoes off the Starling above you with an interesting resonance.`
 			`	"If we can unlock the secrets of these ramscoops, it will give our ships greater range as they search for a safer refuge." As she picks up the remote control for the small loading truck with the two ramscoops she trills at you over her shoulder. "Oh, my name is Tali. I'll let you know what I find."`

--- a/data/remnant missions.txt
+++ b/data/remnant missions.txt
@@ -681,6 +681,7 @@ mission "Remnant: Plasma Turret Check"
 		has "Remnant: Plasma Weapons: offered"
 
 
+
 mission "Remnant: Plasma Weapons"
 	name "Retrieve Plasma Cannons for the Remnant"
 	description "An engineer on <planet> has offered to pay you <payment> in exchange for obtaining two plasma cannons."
@@ -726,11 +727,11 @@ mission "Remnant: Plasma Weapons"
 
 			`	After a bit of negotiation, he agrees to pay you <payment> in exchange for a cargo of two plasma cannons.`
 				accept
-	
+
 	on complete
 		outfit "Plasma Cannon" -2
 		payment 800000
-		
+		event "Remnant: Plasma Cannon Available" 80 160
 		conversation
 			`As <ship> settles onto the pad closest to the research facility, you can see the weapons specialist checking over a large cannon on a platform beneath a nearby Albatross. When he sees you starting to unload the two plasma cannons, he snaps the casing closed and gestures to someone out of sight. Within moments both him and an empty flatbed are there to pick up the weapons.`
 			`	"Thank you for your help," he says. "Our Inhibitors provide us with something of a mobility advantage against the Korath, but they aren't particularly effective at disabling them. These plasma cannons will open new avenues of research for us." He pauses, then continues. "I also included a bonus for you. It is a 'finder's fee,' as we always appreciate new tech."`
@@ -749,7 +750,7 @@ mission "Remnant: Plasma Weapons"
 mission "Remnant: Tali Log Entry"
 	name "Tali Log Entry"
 	source
-		"Remnant"
+		government "Remnant"
 	invisible
 	to offer
 		or
@@ -758,6 +759,19 @@ mission "Remnant: Tali Log Entry"
 			has "Remnant: Heavy Laser: done"
 	on offer
 		log "People" "Tali" `As an engineering prefect, Tali is the foremost authority among the Remnant on salvaged technology and a senior leader in their reverse engineering program.`
+		conversation
+			`A message pops up on your communicator from Tali. The message reads:`
+			`	We are always on the lookout for new technology, no matter the source. If you find any, just get in touch with me.`
+			`				Onwards,`
+			`						Prefect Tali`
+				decline
+
+
+
+event "Remnant: Plasma Cannon Available"
+	outfitter "Remnant"
+		"Plasma Cannon"
+		"Plasma Turret"
 
 
 


### PR DESCRIPTION
- Rewrote a fair bit of the Plasma Weapons mission
- Added branching dialogue for if the player has done the Plasma turret FW missions.
- Added branching dialogue to reflect if the player has met Tali before.
- Added two invisible sub missions to test for Plasma Cannons and Plasma Turrets and trigger the Weapons mission (which also sets things up for easy triggering of other plasma missions
- Broke Tali's Log entry out into a separate mission that will be triggered by any of the retrieval missions. (thus avoiding any duplicate entries)