### PR TITLE
Revert "Added a mission to FWR to account for the player having a broken JD installed"

### DIFF
--- a/data/free worlds reconciliation.txt
+++ b/data/free worlds reconciliation.txt
@@ -1181,8 +1181,8 @@ mission "FW Pug 2C: Hyperdrive"
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
-	source "Hephaestus"
-	destination "Pugglemug"
+	source Hephaestus
+	destination Pugglemug
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
@@ -1206,8 +1206,8 @@ mission "FW Pug 2C: Scram Drive"
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
-	source "Hephaestus"
-	destination "Pugglemug"
+	source Hephaestus
+	destination Pugglemug
 	to offer
 		has "FW Pug 2B: done"
 		not "fw given jump drive"
@@ -1231,8 +1231,8 @@ mission "FW Pug 2C: Jump Drive"
 	landing
 	name "Investigate the Pug"
 	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
-	source "Hephaestus"
-	destination "Pugglemug"
+	source Hephaestus
+	destination Pugglemug
 	clearance
 	to offer
 		has "FW Pug 2B: done"
@@ -1245,32 +1245,6 @@ mission "FW Pug 2C: Jump Drive"
 		outfit "Jump Drive" -1
 		conversation
 			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and asks if they can look over your ship; a few minutes later, one of them says in surprise, "You've already got a Jump Drive! How did you manage that?" Since you don't need their equipment, they urge you to head directly for Pug space and continue your mission.`
-				accept
-	
-	on accept
-		outfit "Jump Drive" 1
-		set "fw given jump drive"
-
-
-
-mission "FW Pug 2C: Jump Drive (Broken)"
-	landing
-	name "Investigate the Pug"
-	description "Travel to the Deneb system to investigate the Pug; if possible, make contact with them and determine what their goals and desires are."
-	source "Hephaestus"
-	destination "Pugglemug"
-	clearance
-	to offer
-		has "FW Pug 2B: done"
-		not "fw given jump drive"
-	passengers 1
-	on fail
-		dialog `You have failed an essential Free Worlds mission. If you want to complete the story line, revert to the autosave or another earlier snapshot of the game.`
-	
-	on offer
-		outfit "Jump Drive (Broken)" -1
-		conversation
-			`You are directed to land in a hangar some distance away from the spaceport, in a cluster of buildings owned by Syndicated Systems. A team of engineers meets you and quickly pull your mangled broken Jump Drive from your ship, replacing it with a working one. "What in the world happened to this?" one of them asks as they look over the broken Jump Drive. You don't have time to explain, as they urge you to head directly for Pug space and continue your mission.`
 				accept
 	
 	on accept


### PR DESCRIPTION
Reverts Zitchas/endless-sky#38

No longer necessary as the broken JD is not a functional drive.