### PR TITLE
Salvage scanner changes

### DIFF
--- a/data/remnant outfits.txt
+++ b/data/remnant outfits.txt
@@ -341,10 +341,6 @@ outfit "Quantum Key Stone"
 	"quantum keystone" 1
 	description "This precious artifact attunes a ship's quantum oscillations in a way that allows it to travel through certain otherwise impassible wormholes in the Ember Waste. The stones are rare and valuable, because they can only be mined from one location in the Waste."
 
-
-
-# Scanner:
-
 outfit "Salvage Scanner"
 	category "Systems"
 	licenses
@@ -356,7 +352,8 @@ outfit "Salvage Scanner"
 	"outfit scan power" 13
 	"outfit scan speed" 1
 	"tactical scan power" 84
-	description "When the Remnant unraveled the secrets of the alien point defence turrets that guarded the vaults they found on Aventine, they also deciphered the mechanisms that guided the ancient weapons. With a little work they transformed those guidance systems into the fundamental tools that supports their aggressive pursuit of new technology."
+	description "When the Remnant unraveled the secrets of the alien point defence turrets that guarded the vaults they found on Aventine, they also deciphered the mechanisms that guided the ancient weapons. With a little work, they transformed those guidance systems into the fundamental tools that supports their aggressive pursuit of new technology."
+	description "	While all Remnant ships have built in outfit and tactical scanners in order to determine whether an enemy ship is worth engaging and looting, some captains still prefer to install external scanners in order to have superior scanning ranges."
 
 
 

--- a/data/remnant ships.txt
+++ b/data/remnant ships.txt
@@ -36,9 +36,9 @@ ship "Albatross"
 		"shield energy" 4.6
 		"hull repair rate" 1.5
 		"hull energy" 1.2
-		"outfit scan power" 50
+		"outfit scan power" 18
 		"outfit scan speed" 1
-		"tactical scan power" 50
+		"tactical scan power" 39
 		weapon
 			"blast radius" 360
 			"shield damage" 3600
@@ -80,7 +80,6 @@ ship "Albatross"
 	explode "huge explosion" 10
 	"final explode" "final explosion large" 1
 	description "Once they left human space, it became apparent to the Remnant that they would need to build their own shipyards in order to defend themselves if they were discovered by the Alphas or any other unfriendly faction. Using new composite materials that they discovered, they built ships very different from anything seen in human space."
-	description "	Spurred on by their exposure to alien ruins, the Remnant have ensured that every ship has detailed scanners built into their hull. While they continue to hope to find wrecks to accompany the ruins, these scanners have proven invaluable in their pursuit of livelier ships."
 
 ship "Albatross" "Albatross (Sniper)"
 	outfits
@@ -201,9 +200,9 @@ ship "Gascraft"
 		"hull repair rate" 1.2
 		"hull energy" 0.9
 		"gaslining" 1
-		"outfit scan power" 26
+		"outfit scan power" 24
 		"outfit scan speed" 1
-		"tactical scan power" 26
+		"tactical scan power" 52
 		"atmosphere scan" 100
 	outfits
 		"Millennium Cell"
@@ -239,7 +238,7 @@ ship "Gull"
 		"fuel capacity" 600
 		"ramscoop" 1
 		"cargo space" 175
-		"outfit space" 316
+		"outfit space" 310
 		"weapon capacity" 83
 		"engine capacity" 101
 		"shield generation" 1.6
@@ -313,7 +312,7 @@ ship "Gull" "Gull (Support)"
 		"Epoch Cell"
 		"Millennium Cell"
 		"Crystal Capacitor"
-		"Salvage Scanner" 3
+		"Salvage Scanner" 2
 		"Outfits Expansion"
 		"Tuning Rifle" 3
 


### PR DESCRIPTION
Removed the `Scanner` comment in the outfits file as the scanner already fits under the category of systems.

Moved the mention of in-built scanners from the Albatross description to the scanner description.

Changed built-in scanners as to 1) not have outfit space equal tactical scanning, and 2) make it so that the Gull with 2 scanners has the highest ranges.

Reverted the Gull's outfit space down to 310 as to have it be lower than the Starling's. Therefore reduced the number of scanners on the Support variant from 3 to 2; this variant still has the highest scanning range of any Remnant ship.