### PR TITLE
Overhauled the Deep: Remnant line

### DIFF
--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1472,7 +1472,7 @@ conversation "deep: remnant"
 	`	"We've analyzed the Keystones, and surprisingly they do allow entry into the wormhole in Terminus," Ivan explains. "It would appear that the stones stabilize the wormhole as the ship passes through it, or maybe it is stabilizing the ship in some way and not the wormhole. We'll need much more time to fully understand the true mechanism that is at play here. Whatever the case is, one stone is required for each ship to pass through the wormhole.`
 	`	"We sent a single drone through the wormhole to test that it was passable, and programmed it to return immediately in case the region beyond is hostile or dangerous. Would you be willing to explore the region for us? You may want to install a ramscoop, as we are unsure if there will be anywhere for your ship to refuel."`
 	branch "know now" "still don't know"
-		not "First Contact: Remnant: offered"
+		has "First Contact: Remnant: offered"
 	
 	label "know now"
 	choice

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1465,7 +1465,7 @@ conversation "deep: remnant"
 	label remnant1
 	`	"Last time, you mentioned that there were humans living in this space, the... the 'Remainder?'"`
 	`	"Remnant," you say.`
-	`	"Right, that was it. Well, it would be extremely interesting if we were to learn more about this people?`
+	`	"Right, that was it. Well, it would be extremely interesting if we were to learn more about this people.`
 		goto end
 	
 	label "didn't know before"

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1310,28 +1310,29 @@ mission "Deep: Remnant 0"
 			`	Ivan looks like he is about to fall over with joy after you mention having entered the wormhole. "Really? Please, tell me what you found!"`
 			branch friendly
 				has "event: ember waste label"
-			`	You tell Ivan all that you saw on the other side of the wormhole, and how you found strange-looking humans who communicate in song and sign language that attacked you after you wouldn't submit to a blood test.`
+			apply
+				set "deep: did reveal remnant"
+			`	You tell Ivan all that you saw on the other side of the wormhole, and how you found strange-looking humans who communicate in song and sign language that attacked you after you wouldn't submit to a blood test. You also mention the other oddities of the region of space, including the strange alien creatures in Nenia that are able to survive in the vacuum of space, as well as the large number of wormholes that allow traversal throughout the region.`
 				goto end
 			
 			label friendly
 			choice
 				`	(Reveal the existence of the Remnant.)`
 				`	(Don't reveal the existence of the Remnant.)`
-					goto secretdanger
+					goto secret
+			apply
+				set "deep: did reveal remnant"
 			`	You tell Ivan about how the region of space beyond the wormhole is known as the "Ember Waste" and that it is inhabited by a group of friendly humans who fled there during the Alpha Wars. These humans have advanced independently from the rest of humanity for centuries. You mention their strange culture, sharing what you can remember about the songs the Remnant people sang.`
+			`	You also mention the other oddities of the Ember Waste, including the strange alien creatures in Nenia that are able to survive in the vacuum of space, as well as the large number of wormholes that allow traversal throughout the region.`
 				goto end
-			label secretdanger
+				
+			label secret
 			apply
 				set "deep: did not reveal remnant"
-			`	You tell Ivan about the region of space beyond the wormhole and its vast loneliness. You describe the ever-present red glow and how the desolate nature of the area led to you calling it the 'Ember Waste.' You also mention how fuel was a constant concern and explain the number of odd wormholes.`
-			`	"This is very interesting, and it would turn out to be an amazing discovery if true. Please, bring us the Quantum Keystones so that we might try to understand the properties which allow entry into the wormhole's threshold. Oh, before I forget: we can pay you for half of the cost of the Keystones."`
-			choice
-				`	"I would be glad to help."`
-					accept
-				`	"Sorry, I don't want to help with this."`
-					decline
+			`	You tell Ivan about the region of space beyond the wormhole and its vast loneliness. You describe the ever-present red glow, similar to the color of the wormhole. You also mention the strange alien creatures in Nenia that are able to survive in the vacuum of space, as well as the large number of wormholes that allow traversal throughout the region.`
+				
 			label end
-			`	"This is very interesting, and would turn out to be an amazing discovery if true. Please, bring us the Quantum Keystones so that we might try to understand the properties which allow entry into the wormhole's threshold. Later we will learn more about these inhabitants you describe. Oh, before I forget: we can pay you for half of the cost of the Keystones."`
+			`	"This is very interesting, and would turn out to be an amazing discovery if true. Please, bring us the Quantum Keystones so that we might try to understand the properties which allow entry into the wormhole's threshold. Later we will learn more about this region that you describe. Oh, before I forget: we can pay you for half of the cost of the Keystones."`
 			choice
 				`	"I would be glad to help."`
 					accept
@@ -1380,8 +1381,7 @@ mission "Deep: Remnant: Keystone Research"
 
 
 
-# Branch A occurs if the player has yet to discover the Remnant
-mission "Deep: Remnant 1A"
+mission "Deep: Remnant A"
 	landing
 	name `Exploring the Unknown`
 	description `Explore the region of space beyond the Terminus wormhole. Return to <destination> after exploring everything you can reach.`
@@ -1391,7 +1391,9 @@ mission "Deep: Remnant 1A"
 		has "Deep: Remnant: Keystone Research: done"
 		not "deep: knew of stones before scientists"
 		not "First Contact: Remnant: offered"
-		not "deep: did not reveal remnant"
+		not "Deep: Remnant 1A: offered"
+		not "Deep: Remnant 1B: offered"
+		not "Deep: Remnant 1C: offered"
 	
 	on offer
 		conversation "deep: remnant"
@@ -1412,231 +1414,204 @@ mission "Deep: Remnant 1A"
 
 
 
-mission "Deep: Remnant 2A"
+mission "Deep: Remnant B"
 	landing
-	name `Analyze Remnant Ships`
-	description `Scan the outfits of the Remnant ships in Arculus, then return to the scientists on <destination> with the detailed scanner logs.`
-	source "Valhalla"
-	waypoint "Arculus"
-	to offer
-		has "Deep: Remnant 1A: done"
-	
-	on offer
-		conversation "deep: remnant"
-	
-	npc "scan outfits"
-		government "Remnant"
-		personality staying uninterested target
-		system "Arculus"
-		fleet
-			names "remnant"
-			variant
-				"Albatross"
-				"Starling"
-		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
-	
-	on visit
-		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <waypoints>. Make sure you're using an outfit scanner as well."`
-	on complete
-		event "deep: scan log research" 14
-		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
-		dialog
-			`The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
-
-
-
-# Branch B occurs if the player discovered the Remnant before "Deep: Remnant: Keystone Research"
-mission "Deep: Remnant 1B"
-	landing
-	name `Analyze Remnant Ships`
-	description `Scan the outfits of the Remnant ships in Arculus, then return to the scientists on <destination> with the detailed scanner logs.`
-	source "Valhalla"
-	waypoint "Arculus"
-	to offer
-		has "Deep: Remnant: Keystone Research: done"
-		has "deep: knew of stones before scientists"
-		not "deep: did not reveal remnant"
-	
-	on offer
-		conversation "deep: remnant"
-	
-	npc "scan outfits"
-		government "Remnant"
-		personality staying uninterested target
-		system "Arculus"
-		fleet
-			names "remnant"
-			variant
-				"Albatross"
-				"Starling"
-		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
-	
-	on visit
-		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <waypoints>. Make sure you're using an outfit scanner as well."`
-	on complete
-		event "deep: scan log research" 14
-		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
-		dialog
-			`The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
-
-
-
-# Branch C occurs if the player discovered the Remnant after "Deep: Remnant: Keystone Research"
-mission "Deep: Remnant 1C"
-	landing
-	name `Analyze Remnant Ships`
-	description `Scan the outfits of the Remnant ships in Arculus, then return to the scientists on <destination> with the detailed scanner logs.`
-	source "Valhalla"
-	waypoint "Arculus"
-	to offer
-		has "Deep: Remnant: Keystone Research: done"
-		not "deep: knew of stones before scientists"
-		has "First Contact: Remnant: offered"
-		not "Deep: Remnant 1A: offered"
-		not "deep: did not reveal remnant"
-	
-	on offer
-		conversation "deep: remnant"
-	
-	npc "scan outfits"
-		government "Remnant"
-		personality staying uninterested target
-		system "Arculus"
-		fleet
-			names "remnant"
-			variant
-				"Albatross"
-				"Starling"
-		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
-	
-	on visit
-		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <waypoints>. Make sure you're using an outfit scanner as well."`
-	on complete
-		event "deep: scan log research" 14
-		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
-		dialog
-			`The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
-
-
-
-# Branch D occurs when the player knew about the Remnant before the start of the mission and decided to not reveal it to the Deep researchers.
-mission "Deep: Remnant 1D"
-	landing
-	name `Analyze Series of Wormholes`
-	description `Scan the series of wormholes located in the Ember Waste.`
+	name `Analyze Wormholes`
+	description `Ivan and his team are interested in studying the wormholes beyond the one in Terminus. Return to the strange region of space and travel through the wormholes that create a loop while carrying the scanning equipment.`
 	source "Valhalla"
 	waypoint "Cardea"
 	waypoint "Insitor"
 	waypoint "Segesta"
 	waypoint "Aescolanus"
 	cargo "astronomical recorders" 5
+	blocked `You've returned to <planet>, but Ivan informs you that you'll need <capacity> available for this next mission. Return when you have the available space.`
 	to offer
-		has "Deep: Remnant: Keystone Research: done"
-		has "deep: knew of stones before scientists"
-		has "First Contact: Remnant: offered"
-		not "Deep: Remnant 1A: offered"
-		has "deep: did not reveal remnant"
+		or
+			has "Deep: Remnant A: done"
+			and
+				has "Deep: Remnant: Keystone Research: done"
+				not "Deep: Remnant A: offered"
+				not "Deep: Remnant 1A: offered"
+				not "Deep: Remnant 1B: offered"
+				not "Deep: Remnant 1C: offered"
+				or
+					has "deep: knew of stones before scientists"
+					has "First Contact: Remnant: offered"
 	on offer
-		conversation
-			`You contact Ivan after you land and he sends you directions to his research lab located on the outskirts of the city. When you arrive, you hardly have time to greet Ivan, Rayna, and the others before Ivan begins discussing what they have learned from the Quantum Keystones.`
-			`	"As you mentioned before, a single Keystone is sufficient to enter the wormhole. We've determined that there is a stabilization effect, either on the ship or the wormhole, that allows matter to cross the threshold. However, we'll need much more time to fully understand the true mechanism." Ivan asks, "Last time, you mentioned that there was an odd series of wormholes?"`
-			`	"Yes. They kind of make a train of sorts."`
-			`	"Right, definitely noteworthy. Well, we've decided that we need to know more about these wormholes, as they could be significant. Could you make the circuit around this loop while carrying a suite of astronomical instruments? "`
-			choice
-				`	"Sure, I'm willing to do it."`
-					accept
-				`	"Sorry, you'll need to find someone else."`
-					decline
+		conversation "deep: remnant"
 	on visit
-		dialog `You have returned to <planet>, but you have not yet visited each system in the wormhole series. Go back and complete the set.`
-	on complete
-		event "deep: scan log research" 14
-		log `Scanned a train of wormholes in the Ember Waste and handed the scan logs over to Ivan and his team.`
-		dialog
-			`The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
-		
-	
+		dialog `You've returned to <planet>, but you haven't traveled through all the wormholes yet. Return to the strange region of space and travel through the loop of wormholes.`
+
+
 
 conversation "deep: remnant"
-	branch 2A1 ABC # Are we in mission 2A or any other mission?
-		has "Deep: Remnant 1A: done"
+	branch "on second mission" "on first mission"
+		has "Deep: Remnant A: done"
 	
-	label ABC # Appears at the beginning of Remnant 1A, 1B, and 1C
+	label "on first mission"
 	`You contact Ivan after you land and he sends you directions to his research lab, located on the outskirts of the city. When you arrive you hardly have time to greet Ivan, Rayna, and the others before Ivan begins discussing what they have learned from the Quantum Keystones.`
-	branch B1 AC1 # Are we in mission 1B or 1A/1C?
-		has "Deep: Remnant: Keystone Research: done"
+	branch "knew before" "didn't know before"
 		has "deep: knew of stones before scientists"
 	
-	label B1 # The end of 1B 
-	`	"As you mentioned before, a single Keystone is sufficient to enter the wormhole. We've determined that there is a stabilization effect, either on the ship or the wormhole, that allows matter to cross the threshold. However, we'll need much more time to fully understand the true mechanism." Ivan asks, "Last time, you mentioned that there were humans living in this space, the... the 'Remainder?'"`
-	`	"Remnant."`
-	`	"Right, that was it. Well, we've decided that we need to know more about their ships and technology - perhaps they have some alternative method of interacting with these unstable wormholes that can accelerate our understanding. Would you kindly bring us some outfit scanning logs from their ships?"`
-	choice
-		`	"Sure, I'm willing to do it."`
-			accept
-		`	"Sorry, you'll need to find someone else."`
-			decline
+	label "knew before"
+	`	"As you mentioned before, a single Keystone is sufficient to enter the wormhole," Ivan says. "We've determined that there is a stabilization effect, either on the ship or the wormhole, that allows matter to cross the threshold. However, we'll need much more time and data to fully understand the true mechanism.`
+	branch remnant1
+		has "deep: did reveal remnant"
+	`	"Last time, you mentioned that there were alien creatures able to survive the vacumm of space, correct?"`
+	`	You nod.`
+	`	"Right. Well, it would be extremely interesting if we were to learn more about these alien creatures.`
+		goto end
+
+	label remnant1
+	`	"Last time, you mentioned that there were humans living in this space, the... the 'Remainder?'"`
+	`	"Remnant," you say.`
+	`	"Right, that was it. Well, it would be extremely interesting if we were to learn more about this people?`
+		goto end
 	
-	label AC1 # The middle section of 1A and 1C
-	`	"We've analyzed the Keystones, and surprisingly they do allow entry into the wormhole in Terminus. It would appear that the stones stabilize the wormhole as the ship passes through it, or maybe it is stabilizing the ship in some way and not the wormhole. We'll need much more time to fully understand the true mechanism that is at play here. Whatever the case is, one stone is required for each ship to pass through the wormhole.`
+	label "didn't know before"
+	`	"We've analyzed the Keystones, and surprisingly they do allow entry into the wormhole in Terminus," Ivan explains. "It would appear that the stones stabilize the wormhole as the ship passes through it, or maybe it is stabilizing the ship in some way and not the wormhole. We'll need much more time to fully understand the true mechanism that is at play here. Whatever the case is, one stone is required for each ship to pass through the wormhole.`
 	`	"We sent a single drone through the wormhole to test that it was passable, and programmed it to return immediately in case the region beyond is hostile or dangerous. Would you be willing to explore the region for us? You may want to install a ramscoop, as we are unsure if there will be anywhere for your ship to refuel."`
-	branch 1A 1C1 # Are we in mission 1A or 1C?
-		has "Deep: Remnant: Keystone Research: done"
-		not "deep: knew of stones before scientists"
+	branch "know now" "still don't know"
 		not "First Contact: Remnant: offered"
 	
-	label 1A # The end of 1A
+	label "know now"
 	choice
-		`	"I'm always willing to go on an adventure."`
-		`	"This sounds too risky. You're going to need to find someone else to go exploring."`
-			decline
-			
-	`	"Splendid! We will give you a single Quantum Keystone in order to travel through the wormhole. Return here once you have finished exploring."`
-		accept
-	
-	label 1C1 # The choice of 1C
-	choice
-		`	"I already explored the region beyond the wormhole while you were researching."`
-			goto AC2
+		`	"Actually, I already explored the region beyond the wormhole while you were researching."`
+			goto skip
 		`	"Sorry, I don't want to work for you anymore."`
 			decline
 	
-	label 2A1 # Only appears in Remnant 2A
+	label "on second mission"
 	`When you return, Ivan and the rest of the scientists wait eagerly for you to explain what you discovered.`
-	`	You begin by recounting your experience with the strange space-dwelling creatures you found in the Nenia system. Ivan's eyes go wide when you mention the ease with which they fed on asteroids, and how they seemed to effortlessly escape from the gravity of local gas giants.`
-		goto AC2
 	
-	label AC2 # The end of 2A and 1C
-	branch 2A2 1C2 # Are we in mission 2A or 1C?
-		has "Deep: Remnant 1A: done"
-	
-	label 2A2
-	branch friendly1
+	label skip
+	`	You begin by recounting your experience with the strange space-dwelling creatures you found in the Nenia system. Ivan's eyes go wide when you mention the ease with which they fed on asteroids, and how they seemed to effortlessly escape from the gravity of local gas giants. You also mention that there are more strange wormholes like the one that you passed through to enter the region of space, including a series of wormholes that create a loop between multiple systems.`
+	branch friendly
 		has "event: ember waste label"
+	apply
+		set "deep: did reveal remnant"
 	`	You then tell them about the strange-looking humans who communicate in song and sign language that attacked you after you wouldn't submit to a blood test.`
-		goto AC3
+		goto remnant2
 				
-	label friendly1
+	label friendly
+	choice
+		`	(Reveal the existence of the Remnant.)`
+		`	(Don't reveal the existence of the Remnant.)`
+			goto secret
+	apply
+		set "deep: did reveal remnant"
 	`	You then tell them about the Remnant, a group of friendly humans who fled human space during the Alpha Wars and have advanced independently of humanity for centuries, and how they call the region of space the "Ember Waste."`
-		goto AC3
-	
-	label 1C2
-	branch friendly2
-		has "event: ember waste label"
-	`	The scientists look very surprised, and ask that you tell them what you found. You recall your encounter with strange-looking humans who communicate in song and sign language and attacked you after you wouldn't submit to a blood test.`
-		goto AC3
-				
-	label friendly2
-	`	The scientists look very surprised, and ask that you tell them what you found. You recall your encounter with the Remnant, a group of friendly humans who fled human space during the Alpha Wars and have advanced independently of humanity for centuries, and how they call the region of space the "Ember Waste."`
-		goto AC3
-	
-	label AC3
+		goto remnant2
+
+	label secret
+	apply
+		set "deep: did not reveal remnant"
+	`	The group of scientists looks captivated the entire time, almost like kindergarten children listening to a fairy tale. When you finish talking, they immediately chatter among themselves, seeming to be most interested in the alien creaturess which inhabit the region. They seem to agree that they need to learn more about these aliens.`
+	`	"We can seek to learn more about these alien creatures later," Ivan says.`
+		goto end
+		
+	label remnant2
 	`	The group of scientists looks captivated the entire time, almost like kindergarten children listening to a fairy tale. When you finish talking, they immediately chatter among themselves, seeming to be most interested in the human beings which inhabit the region. They seem to agree that they need to learn more about these humans, and more specifically about the technology which they have developed.`
-	`	They eventually come to the conclusion that you should return to this region of space and scan the ships of these humans so that they can learn more about them.`
+	`	"We can seek to learn more about this group of humans later," Ivan says.`
+
+	label end
+	`	"But, first and foremost, we should continue our work on understanding these wormholes. You mentioned a strange series of wormholes. Their behavior is definitely noteworthy. Could you return to this region of space while carrying a suite of astronomical instruments? If you travel through these wormholes, we may learn more about what makes them tick."`
 	choice
 		`	"Okay, I'm willing to do it."`
+		`	"Sorry, but I didn't agree to help you beyond that first job. Goodbye."`
+			decline
+	`	"Wonderful! We'll get the instruments loaded onto your ship immediately."`
+		accept
+
+	label "still don't know"
+	choice
+		`	"I'm always willing to go on an adventure."`
+		`	"This sounds too risky. You're going to need to find someone else to go exploring."`
+			decline	
+	`	"Splendid! We will give you a single Quantum Keystone in order to travel through the wormhole. Return here once you have finished exploring."`
+		accept
+
+
+
+mission "Deep: Remnant C: Secret"
+	name `Analyze Alien Creatures`
+	description `Scan the "outfits" of the alien creatures in Nenia, then return to the scientists on <destination> with the detailed scanner logs.`
+	source "Valhalla"
+	waypoint "Nenia"
+	to offer
+		has "Deep: Remnant B: done"
+		has "deep: did not reveal remnant"
+	
+	on offer
+		conversation "deep: remnant c"
+	
+	npc "scan outfits"
+		government "Indigenous Lifeform"
+		personality timid mining harvests staying mute
+		system "Nenia"
+		fleet
+			cargo 0
+			variant
+				"Void Sprite"
+				"Void Sprite (Infant)"
+		dialog `You have finished scanning the alien creatures in the system. You may now return to <destination> with the scanner logs.`
+	
+	on visit
+		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more creatures for you to scan in <waypoints>. Make sure you're using an outfit scanner as well."`
+	on complete
+		event "deep: scan log research" 14
+		log `Scanned alien creatures beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
+		dialog `The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
+
+
+
+mission "Deep: Remnant C: Revealed"
+	name `Analyze Remnant Ships`
+	description `Scan the outfits of the Remnant ships in Arculus, then return to the scientists on <destination> with the detailed scanner logs.`
+	source "Valhalla"
+	waypoint "Arculus"
+	to offer
+		has "Deep: Remnant B: done"
+		has "deep: did reveal remnant"
+	
+	on offer
+		conversation "deep: remnant c"
+	
+	npc "scan outfits"
+		government "Remnant"
+		personality staying uninterested target
+		system "Arculus"
+		fleet
+			names "remnant"
+			variant
+				"Albatross"
+				"Starling"
+		dialog `You have finished scanning the Remnant ships in the system. You may now return to <destination> with the scanner logs.`
+	
+	on visit
+		dialog `You show your scanner logs to Ivan, but he shakes his head. "This isn't enough. There should be more ships for you to scan in <waypoints>. Make sure you're using an outfit scanner as well."`
+	on complete
+		event "deep: scan log research" 14
+		log `Scanned Remnant ships beyond the wormhole in Terminus and handed the scan logs over to Ivan and his team.`
+		dialog `The team is visibly excited when you return with the scanner logs. "Give us a few weeks to look these over," Ivan says. "Then we will contact you about what we want you to do next."`
+
+
+
+conversation "deep: remnant c"
+	`The team of scientists is already waiting in the spaceport when you arrive. They remove the equipment from your ship and immediately being analyzing the results after returning to the lab.`
+	`	"At first glance this series of wormholes seems no different than the one that is used to enter this region of space, but it will require some time for us to go over all the data the sensors collected," Ivan explains to you.`
+	branch revealed
+		has "deep: did reveal remnant"
+	`	"While you wait, though, I have another job you could do. You mentioned something about strange alien creatures beyond the wormhole that seemed to be able to survive in the vacuum of space. Would you be able to return there and scan them for us? These alien creatures won't have 'outifts' for the scanners to pick up, but a typical outfits scanner is likely to give us the most information."`
+		goto end
+
+	label revealed
+	`	"While you wait, though, I have another job you could do. You mentioned something about a group of humans, or at least human-like beings, being the wormhole. Would you be able to return there and scan their ships for us? I'd be interested in seeing what an outfits scanner returns. You need not contact them, simply find a couple ships and scan them so that we might learn more about their capabilities."`
+	label end
+	choice
+		`	"Sounds like a good plan. I'll be back as fast as I can."`
 			accept
-		`	"This seems too risky for me. You'll need to find someone else."`
+		`	"Sorry, but I'm not comfortable with this idea. You'll need to find someone else."`
 			decline
 
 
@@ -1655,11 +1630,22 @@ mission "Deep: Remnant Technology"
 	destination "Valhalla"
 	to offer
 		has "event: deep: scan log research"
-		not "deep: did not reveal remnant"
 	
 	on offer
 		payment 250000
-		dialog `You receive a message from Ivan after you land. "Thanks for all your help recently. We brought our findings to the Deep government and they gave us more funding! We've transferred <payment> to your account and made sure you were listed as a primary contributor on all the reports of these immense discoveries. Please meet us on <destination> if you wish to assist us further. Your help would be appreciated, but we will make progress even if you're a bit busy at the moment."`
+		conversation
+			branch technology
+				has "deep: did reveal remnant"
+			`You receive a message from Ivan after you land. "Thanks for all your help recently. We brought our findings to the Deep government, and they gave us more funding! We've transferred <payment> to your account and made sure you were listed as a primary contributor on all the reports of these immense discoveries. We do not have any further jobs for you, but hopefully we will in the future. Thanks again!"`
+				decline
+			
+			label technology
+			`You receive a message from Ivan after you land. "Thanks for all your help recently. We brought our findings to the Deep government and they gave us more funding! We've transferred <payment> to your account and made sure you were listed as a primary contributor on all the reports of these immense discoveries. Please meet us on <destination> if you wish to assist us further. Your help would be appreciated, but we will make progress even if you're a bit busy at the moment."`
+			choice
+				`	(Accept.)`
+					accept
+				`	(Decline.)`
+					decline
 	on decline
 		set "Deep: Remnant Research: done"
 	on fail
@@ -1667,21 +1653,17 @@ mission "Deep: Remnant Technology"
 
 
 
-mission "Deep: Wormhole Research"
+# Patch mission for v0.9.13. If the player finished these missions prior to this update, then that means they must have revealed the existence of the Remnant to the Deep.
+mission "deep: player revealed remnant"
 	landing
-	source
-		government "Republic" "Free Worlds" "Syndicate" "Neutral" "Independent"
-		not system "Epsilon Leonis"
-	destination "Valhalla"
+	invisible
 	to offer
-		has "event: deep: scan log research"
-		has "deep: did not reveal remnant"
+		has "Deep: Remnant Research: done"
+		not "deep: did reveal remnant"
+		not "deep: did not reveal remnant"
 	on offer
-		payment 250000
-		conversation `You receive a message from Ivan after you land. "Thanks for all your help recently. We brought our findings to the Deep government, and they gave us more funding! We've transferred <payment> to your account and made sure you were listed as a primary contributor on all the reports of these immense discoveries. We do not have any further jobs for you, but hopefully we will in the future. Thanks again!"`
-			decline
-	on decline
-		set "Deep: Remnant Research: done"
+		set "deep: did reveal remnant"
+		fail
 
 
 

--- a/data/human/deep missions.txt
+++ b/data/human/deep missions.txt
@@ -1606,7 +1606,7 @@ conversation "deep: remnant c"
 		goto end
 
 	label revealed
-	`	"While you wait, though, I have another job you could do. You mentioned something about a group of humans, or at least human-like beings, being the wormhole. Would you be able to return there and scan their ships for us? I'd be interested in seeing what an outfits scanner returns. You need not contact them, simply find a couple ships and scan them so that we might learn more about their capabilities."`
+	`	"While you wait, though, I have another job you could do. You mentioned something about a group of humans, or at least human-like beings, beyond the wormhole. Would you be able to return there and scan their ships for us? I'd be interested in seeing what an outfits scanner returns. You need not contact them, simply find a couple ships and scan them so that we might learn more about their capabilities."`
 	label end
 	choice
 		`	"Sounds like a good plan. I'll be back as fast as I can."`


### PR DESCRIPTION
* The player is now able to choose whether to reveal the existence of the Remnant at any point where they had previously mentioned them, instead of only being able to choose at the first possible instance as this branch had done previously.
* GREATLY simplified the mission structure; instead three or four branches of missions, now mainly only the conversation branches, with one fork in the missions in the middle. (This should really have been the case from the beginning; guess I hadn't thought of how to do it like this back then.)
* The progression is now as follows:
   * Bring Keystones to the Deep scientists.
   * Explore the Ember Waste (if the player didn't already do so).
   * Travel through the wormhole loop.
   * Scan two Remnant ships (if the player told about the Remnant).
   * Scan two void sprites (if the player kept the Remnant a secret).
   * Bring Remnant technology to the Deep (if the player told about the Remnant).
* Old pilots that have already done these missions will gain the "deep: did reveal remnant" condition, as prior to this the player must have always done so.

This PR does not touch the Remnant side of things for this branch, at least right now. I'd like to tackle that, though.