### PR TITLE
Up-massed Alien ships.

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -20,7 +20,7 @@ ship "Arach Courier"
 		"hull" 2000
 		"required crew" 1
 		"bunks" 1
-		"mass" 100
+		"mass" 50
 		"drag" 2.9
 		"heat dissipation" .65
 		"fuel capacity" 300
@@ -65,7 +65,7 @@ ship "Arach Freighter"
 		"hull" 8500
 		"required crew" 3
 		"bunks" 10
-		"mass" 380
+		"mass" 400
 		"drag" 10.6
 		"heat dissipation" .55
 		"fuel capacity" 500
@@ -115,7 +115,7 @@ ship "Arach Hulk"
 		"hull" 13800
 		"required crew" 8
 		"bunks" 14
-		"mass" 737
+		"mass" 1000
 		"drag" 18.9
 		"heat dissipation" .50
 		"fuel capacity" 500
@@ -169,7 +169,7 @@ ship "Arach Spindle"
 		"hull" 9700
 		"required crew" 4
 		"bunks" 14
-		"mass" 374
+		"mass" 500
 		"drag" 10.8
 		"heat dissipation" .55
 		"fuel capacity" 500
@@ -391,7 +391,7 @@ ship "Heliarch Hunter"
 		"hull" 45300
 		"required crew" 26
 		"bunks" 41
-		"mass" 441
+		"mass" 630
 		"drag" 5.3
 		"heat dissipation" .71
 		"ion protection" .2
@@ -549,7 +549,7 @@ ship "Heliarch Interdictor"
 		"hull" 54600
 		"required crew" 42
 		"bunks" 70
-		"mass" 546
+		"mass" 780
 		"drag" 7.4
 		"heat dissipation" .70
 		"ion protection" .2
@@ -673,7 +673,7 @@ ship "Heliarch Judicator"
 		"hull" 41900
 		"required crew" 31
 		"bunks" 110
-		"mass" 504
+		"mass" 720
 		"drag" 7.9
 		"heat dissipation" .67
 		"ion protection" .2
@@ -970,7 +970,7 @@ ship "Heliarch Punisher"
 		"hull" 85000
 		"required crew" 96
 		"bunks" 145
-		"mass" 858
+		"mass" 1500
 		"drag" 12.2
 		"heat dissipation" .60
 		"ion protection" .3
@@ -1335,7 +1335,7 @@ ship "Kimek Briar"
 		"hull" 1700
 		"required crew" 3
 		"bunks" 25
-		"mass" 180
+		"mass" 150
 		"drag" 3.8
 		"heat dissipation" .75
 		"fuel capacity" 700
@@ -1381,7 +1381,7 @@ ship "Kimek Spire"
 		"hull" 4900
 		"required crew" 19
 		"bunks" 197
-		"mass" 627
+		"mass" 800
 		"drag" 8.4
 		"heat dissipation" .60
 		"fuel capacity" 800
@@ -1435,7 +1435,7 @@ ship "Kimek Thistle"
 		"hull" 2800
 		"required crew" 7
 		"bunks" 52
-		"mass" 284
+		"mass" 300
 		"drag" 5.8
 		"heat dissipation" .70
 		"fuel capacity" 700
@@ -1484,7 +1484,7 @@ ship "Kimek Thorn"
 		"hull" 800
 		"required crew" 1
 		"bunks" 7
-		"mass" 80
+		"mass" 50
 		"drag" 1.8
 		"heat dissipation" .80
 		"fuel capacity" 600
@@ -1529,7 +1529,7 @@ ship "Saryd Runabout"
 		"hull" 1400
 		"required crew" 2
 		"bunks" 13
-		"mass" 140
+		"mass" 70
 		"drag" 2.8
 		"heat dissipation" .70
 		"fuel capacity" 400
@@ -1572,7 +1572,7 @@ ship "Saryd Sojourner"
 		"hull" 7700
 		"required crew" 17
 		"bunks" 84
-		"mass" 704
+		"mass" 900
 		"drag" 12.9
 		"heat dissipation" .50
 		"fuel capacity" 800
@@ -1627,7 +1627,7 @@ ship "Saryd Traveler"
 		"hull" 4000
 		"required crew" 10
 		"bunks" 45
-		"mass" 368
+		"mass" 450
 		"drag" 5.5
 		"heat dissipation" .60
 		"fuel capacity" 600
@@ -1680,7 +1680,7 @@ ship "Saryd Visitor"
 		"hull" 2400
 		"required crew" 5
 		"bunks" 29
-		"mass" 270
+		"mass" 300
 		"drag" 4.4
 		"heat dissipation" .65
 		"fuel capacity" 400

--- a/data/hai/hai ships.txt
+++ b/data/hai/hai ships.txt
@@ -73,7 +73,7 @@ ship "Centipede"
 		"hull" 2400
 		"required crew" 35
 		"bunks" 131
-		"mass" 197
+		"mass" 400
 		"drag" 3.9
 		"heat dissipation" .75
 		"fuel capacity" 600
@@ -192,7 +192,7 @@ ship "Geocoris"
 		"hull" 6200
 		"required crew" 15
 		"bunks" 56
-		"mass" 891
+		"mass" 1500
 		"drag" 17.1
 		"heat dissipation" 0.45
 		"fuel capacity" 800
@@ -566,7 +566,7 @@ ship "Shield Beetle"
 		"hull" 9800
 		"required crew" 47
 		"bunks" 95
-		"mass" 715
+		"mass" 1300
 		"drag" 8.8
 		"heat dissipation" .60
 		"fuel capacity" 500
@@ -755,7 +755,7 @@ ship "Solifuge"
 		"hull" 11000
 		"required crew" 62
 		"bunks" 118
-		"mass" 1018
+		"mass" 2000
 		"drag" 15.4
 		"heat dissipation" .42
 		"fuel capacity" 600
@@ -981,7 +981,7 @@ ship "Water Bug"
 		"hull" 4500
 		"required crew" 5
 		"bunks" 29
-		"mass" 297
+		"mass" 400
 		"drag" 5.9
 		"heat dissipation" .75
 		"fuel capacity" 600

--- a/data/korath/korath ships.txt
+++ b/data/korath/korath ships.txt
@@ -19,7 +19,7 @@ ship "Korath Dredger"
 		"hull" 16000
 		"required crew" 201
 		"bunks" 395
-		"mass" 1654
+		"mass" 2500
 		"drag" 18.3
 		"heat dissipation" .65
 		"fuel capacity" 900
@@ -121,7 +121,7 @@ ship "Korath Raider"
 		"hull" 9000
 		"required crew" 145
 		"bunks" 250
-		"mass" 756
+		"mass" 1000
 		"drag" 12
 		"heat dissipation" .5
 		"fuel capacity" 600
@@ -303,7 +303,7 @@ ship "Korath World-Ship"
 		hull 34000
 		"required crew" 794
 		"bunks" 1492
-		"mass" 2082
+		"mass" 3500
 		"drag" 21
 		"heat dissipation" .4
 		"fuel capacity" 1000
@@ -515,7 +515,7 @@ ship "Kar Ik Vot 349"
 		"shields" 57200
 		"hull" 65400
 		"automaton" 1
-		"mass" 1485
+		"mass" 2700
 		"drag" 16.8
 		"heat dissipation" .5
 		"fuel capacity" 400
@@ -672,7 +672,7 @@ ship "Tek Far 71 - Lek"
 		"shields" 25400
 		"hull" 29500
 		"automaton" 1
-		"mass" 641
+		"mass" 900
 		"drag" 9.6
 		"heat dissipation" .6
 		"fuel capacity" 400
@@ -765,7 +765,7 @@ ship "Tek Far 78 - Osk"
 		"shields" 27600
 		"hull" 34100
 		"automaton" 1
-		"mass" 725
+		"mass" 1000
 		"drag" 10.2
 		"heat dissipation" .55
 		"fuel capacity" 400
@@ -857,7 +857,7 @@ ship "Tek Far 109"
 		"shields" 17900
 		"hull" 15800
 		"automaton" 1
-		"mass" 567
+		"mass" 800
 		"drag" 9.1
 		"heat dissipation" .65
 		"fuel capacity" 400
@@ -928,7 +928,7 @@ ship "Met Par Tek 53"
 		"shields" 15100
 		"hull" 22200
 		"automaton" 1
-		"mass" 420
+		"mass" 650
 		"drag" 5.7
 		"heat dissipation" .8
 		"fuel capacity" 400
@@ -1254,7 +1254,7 @@ ship "Model 64"
 		"shields" 41700
 		"hull" 18000
 		"automaton" 1
-		"mass" 609
+		"mass" 870
 		"drag" 11.1
 		"heat dissipation" 1.1
 		"fuel capacity" 400
@@ -1310,7 +1310,7 @@ ship "Model 128"
 		"shields" 57000
 		"hull" 23100
 		"automaton" 1
-		"mass" 819
+		"mass" 1170
 		"drag" 13.2
 		"heat dissipation" 1.0
 		"fuel capacity" 400
@@ -1367,7 +1367,7 @@ ship "Model 256"
 		"shields" 71700
 		"hull" 28700
 		"automaton" 1
-		"mass" 1067
+		"mass" 1940
 		"drag" 15.3
 		"heat dissipation" .9
 		"fuel capacity" 400
@@ -1426,7 +1426,7 @@ ship "Model 512"
 		"shields" 86400
 		"hull" 34200
 		"automaton" 1
-		"mass" 1265
+		"mass" 2300
 		"drag" 17.4
 		"heat dissipation" .8
 		"fuel capacity" 400

--- a/data/pug/pug.txt
+++ b/data/pug/pug.txt
@@ -555,7 +555,7 @@ ship "Pug Enfolta"
 		"hull" 1700
 		"required crew" 19
 		"bunks" 27
-		"mass" 431
+		"mass" 600
 		"drag" 5.9
 		"heat dissipation" .7
 		"fuel capacity" 600
@@ -610,7 +610,7 @@ ship "Pug Maboro"
 		"hull" 2700
 		"required crew" 54
 		"bunks" 87
-		"mass" 1034
+		"mass" 1800
 		"drag" 9.8
 		"heat dissipation" .6
 		"fuel capacity" 600
@@ -667,7 +667,7 @@ ship "Pug Arfecta"
 		"hull" 80000
 		"required crew" 36
 		"bunks" 46
-		"mass" 704
+		"mass" 960
 		"drag" 7.5
 		"heat dissipation" .8
 		"fuel capacity" 1200

--- a/data/quarg/quarg ships.txt
+++ b/data/quarg/quarg ships.txt
@@ -18,7 +18,7 @@ ship "Quarg Skylark"
 		"hull" 70000
 		"required crew" 120
 		"bunks" 210
-		"mass" 460
+		"mass" 1000
 		"drag" 12.3
 		"heat dissipation" .7
 		"fuel capacity" 1000
@@ -72,7 +72,7 @@ ship "Quarg Wardragon"
 		"hull" 50000
 		"required crew" 160
 		"bunks" 185
-		"mass" 360
+		"mass" 600
 		"drag" 9.3
 		"heat dissipation" .5
 		"fuel capacity" 800

--- a/data/remnant/remnant ships.txt
+++ b/data/remnant/remnant ships.txt
@@ -24,7 +24,7 @@ ship "Albatross"
 		"required crew" 44
 		"bunks" 75
 		"cargo space" 124
-		"mass" 641
+		"mass" 900
 		"drag" 8.6
 		"heat dissipation" 0.6
 		"fuel capacity" 600
@@ -245,7 +245,7 @@ ship "Gull"
 		"hull" 2500
 		"required crew" 3
 		"bunks" 20
-		"mass" 270
+		"mass" 300
 		"drag" 6
 		"heat dissipation" 0.7
 		"fuel capacity" 600
@@ -384,7 +384,7 @@ ship "Heron"
 		"hull" 250500
 		"required crew" 1000
 		"bunks" 3000
-		"mass" 5000
+		"mass" 9000
 		"drag" 25
 		"heat dissipation" .80
 		"fuel capacity" 2500
@@ -512,7 +512,7 @@ ship "Ibis"
 		"hull" 6200
 		"required crew" 16
 		"bunks" 36
-		"mass" 368
+		"mass" 550
 		"drag" 5.1
 		"heat dissipation" 0.7
 		"fuel capacity" 700
@@ -591,7 +591,7 @@ ship "Pelican"
 		"required crew" 14
 		"bunks" 35
 		"cargo space" 302
-		"mass" 320
+		"mass" 550
 		"drag" 7.2
 		"heat dissipation" 0.7
 		"fuel capacity" 600
@@ -772,7 +772,7 @@ ship "Peregrine"
 		"hull" 8600
 		"required crew" 9
 		"bunks" 25
-		"mass" 350
+		"mass" 500
 		"drag" 4.3
 		"heat dissipation" 0.85
 		"fuel capacity" 900

--- a/data/sheragi/sheragi ships.txt
+++ b/data/sheragi/sheragi ships.txt
@@ -18,7 +18,7 @@ ship "Emerald Sword"
 		"hull" 45000
 		"required crew" 86
 		"bunks" 302
-		"mass" 1672
+		"mass" 3200
 		"drag" 20
 		"heat dissipation" 0.45
 		"fuel capacity" 900

--- a/data/wanderer/wanderer ships.txt
+++ b/data/wanderer/wanderer ships.txt
@@ -209,7 +209,7 @@ ship "Strong Wind"
 		"hull" 19600
 		"required crew" 17
 		"bunks" 39
-		"mass" 273
+		"mass" 390
 		"drag" 4.7
 		"heat dissipation" .7
 		"fuel capacity" 600
@@ -267,7 +267,7 @@ ship "Tempest"
 		"hull" 25900
 		"required crew" 38
 		"bunks" 53
-		"mass" 336
+		"mass" 480
 		"drag" 6.2
 		"heat dissipation" 0.65
 		"fuel capacity" 600
@@ -366,7 +366,7 @@ ship "Derecho"
 		"hull" 32700
 		"required crew" 53
 		"bunks" 82
-		"mass" 594
+		"mass" 1000
 		"drag" 8.7
 		"heat dissipation" 0.6
 		"fuel capacity" 500
@@ -467,7 +467,7 @@ ship "Hurricane"
 		"hull" 46500
 		"required crew" 76
 		"bunks" 117
-		"mass" 847
+		"mass" 1600
 		"drag" 11.9
 		"heat dissipation" 0.55
 		"fuel capacity" 500
@@ -737,7 +737,7 @@ ship "Deep River"
 		"hull" 47500
 		"required crew" 13
 		"bunks" 22
-		"mass" 825
+		"mass" 1500
 		"drag" 9.4
 		"heat dissipation" .6
 		"fuel capacity" 500
@@ -826,7 +826,7 @@ ship "Deep River Transport"
 		"hull" 47500
 		"required crew" 13
 		"bunks" 166
-		"mass" 825
+		"mass" 1500
 		"drag" 9.4
 		"heat dissipation" .6
 		"fuel capacity" 500
@@ -878,7 +878,7 @@ ship "Riptide"
 		"hull" 22350
 		"required crew" 47
 		"bunks" 233
-		"mass" 550
+		"mass" 1000
 		"drag" 7.3
 		"heat dissipation" .7
 		"fuel capacity" 800


### PR DESCRIPTION
Coalition, Heliarch, Hai, Korath, Pug, Remnant, Sheragi, and Wanderer ships' mass changed.

Alien ships increased in mass to match human ship changes.

Generally speaking (with some exceptions) the following applies:
Heavy Warships are 2x mass.
Medium Warships are 1.5x mass.
Some light freighters increased in mass by about 20% (what should be "medium freighters")
Most Heavy Freighters are 2x mass.
Transports are treated like Freighters, only more leniently (requiring more size before being up-massed, and gaining less additional mass).
"Agile" ships' mass changed by about 10% less (basically just rounding down).
The smallest Coalition ships were down-massed as if they were Interceptors (but not outfit or engine capacity changes).