### PR TITLE
Expanded in-system distances

### DIFF
--- a/data/map.txt
+++ b/data/map.txt
@@ -77,8 +77,8 @@ system "1 Axis"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 745.92
-	belt 1112
+	habitable 2757.77
+	belt 4296.35
 	link "Sol Kimek"
 	link "4 Winter Rising"
 	link "4 Spring Rising"
@@ -111,28 +111,28 @@ system "1 Axis"
 	fleet Heliarch 450
 	object
 		sprite star/k5
-		distance 49.335
+		distance 137.87
 		period 18.0618
 		offset 180
 	object
 		sprite star/m0
-		distance 65.665
+		distance 188.67
 		period 18.0618
 	object
 		sprite planet/rock12-b
-		distance 298.105
+		distance 998.79
 		period 75.382
 	object
 		sprite planet/cloud4-b
-		distance 728.595
+		distance 2686.8
 		period 288.034
 	object "Celestial Third"
 		sprite planet/ice4
-		distance 951.355
+		distance 3612.66
 		period 429.762
 	object
 		sprite planet/gas9-b
-		distance 1811.79
+		distance 7394.23
 		period 1129.48
 		object
 			sprite planet/lava0
@@ -156,8 +156,8 @@ system "10 Pole"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 486.68
-	belt 1765
+	habitable 1717.88
+	belt 7181.97
 	haze _menu/haze-67
 	link "16 Autumn Rising"
 	asteroids "small rock" 30 10.7996
@@ -189,11 +189,11 @@ system "10 Pole"
 		period 10
 	object
 		sprite planet/ice2
-		distance 158.89
+		distance 498.72
 		period 36.3148
 	object "Second Rose"
 		sprite planet/cloud4
-		distance 483.25
+		distance 1704.48
 		period 192.618
 		object
 			sprite planet/rock17
@@ -201,15 +201,15 @@ system "10 Pole"
 			period 17.6262
 	object
 		sprite planet/lava2-b
-		distance 1069.5
+		distance 4114.29
 		period 634.175
 	object
 		sprite planet/gas16
-		distance 1649.46
+		distance 6660.68
 		period 1214.65
 	object
 		sprite planet/gas8-b
-		distance 2382.55
+		distance 10031.44
 		period 2108.63
 		object
 			sprite planet/rhea
@@ -229,8 +229,8 @@ system "11 Autumn Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1566.68
-	belt 1099
+	habitable 6289.78
+	belt 4240.57
 	haze _menu/haze-133
 	link "16 Autumn Rising"
 	link "Sol Kimek"
@@ -263,16 +263,16 @@ system "11 Autumn Above"
 	fleet Heliarch 400
 	object
 		sprite star/g0
-		distance 40.3837
+		distance 110.71
 		period 14.9791
 	object
 		sprite star/k0
-		distance 89.6163
+		distance 265.51
 		period 14.9791
 		offset 180
 	object
 		sprite planet/gas10-hot
-		distance 536.616
+		distance 1914.18
 		period 125.622
 		object
 			sprite planet/ice8
@@ -284,7 +284,7 @@ system "11 Autumn Above"
 			period 21.8151
 	object
 		sprite planet/rock12-b
-		distance 1117.31
+		distance 4319.15
 		period 377.423
 		object
 			sprite planet/rock3-b
@@ -292,7 +292,7 @@ system "11 Autumn Above"
 			period 19.9116
 	object
 		sprite planet/gas12
-		distance 2339.35
+		distance 9828.96
 		period 1143.44
 		object
 			sprite planet/europa-b
@@ -312,8 +312,8 @@ system "11 Spring Below"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 912.6
-	belt 1932
+	habitable 3449.61
+	belt 7942.47
 	link "4 Spring Rising"
 	link "3 Axis"
 	link "5 Spring Below"
@@ -344,16 +344,16 @@ system "11 Spring Below"
 	fleet Heliarch 500
 	object
 		sprite star/k0
-		distance 47.6045
+		distance 132.58
 		period 13.6402
 		offset 180
 	object
 		sprite star/k5
-		distance 54.3955
+		distance 153.46
 		period 13.6402
 	object
 		sprite planet/rock16-b
-		distance 318.396
+		distance 1074.21
 		period 75.2264
 		object
 			sprite planet/tethys-b
@@ -361,11 +361,11 @@ system "11 Spring Below"
 			period 16.8311
 	object
 		sprite planet/dust7-b
-		distance 583.206
+		distance 2099.19
 		period 186.489
 	object "Third Umber"
 		sprite planet/rock4
-		distance 1145.97
+		distance 4442.44
 		period 513.662
 		object
 			sprite planet/oberon-b
@@ -373,7 +373,7 @@ system "11 Spring Below"
 			period 15.8958
 	object
 		sprite planet/gas3-b
-		distance 2916.97
+		distance 12570.18
 		period 2086.01
 		object
 			sprite planet/rhea
@@ -393,8 +393,8 @@ system "12 Autumn Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1050.92
-	belt 1283
+	habitable 4034.96
+	belt 5036.71
 	link "14 Pole"
 	link "16 Autumn Rising"
 	asteroids "small rock" 23 1.92
@@ -425,28 +425,28 @@ system "12 Autumn Above"
 	fleet Heliarch 800
 	object
 		sprite star/g5
-		distance 49.4445
+		distance 138.21
 		period 16.627
 		offset 180
 	object
 		sprite star/k5
-		distance 72.5555
+		distance 210.52
 		period 16.627
 	object
 		sprite planet/lava2-b
-		distance 256.965
+		distance 847.65
 		period 50.8262
 	object
 		sprite planet/mars-b
-		distance 428.975
+		distance 1493.85
 		period 109.629
 	object
 		sprite planet/ganymede-b
-		distance 603.065
+		distance 2178.57
 		period 182.735
 	object
 		sprite planet/gas17
-		distance 1074.32
+		distance 4134.9
 		period 434.483
 		object
 			sprite planet/europa-b
@@ -458,7 +458,7 @@ system "12 Autumn Above"
 			period 26.1963
 	object
 		sprite planet/gas13-b
-		distance 2145.85
+		distance 8927.56
 		period 1226.52
 		offset 159.403
 		object "Station Cian"
@@ -468,7 +468,7 @@ system "12 Autumn Above"
 			offset 170.143
 	object
 		sprite planet/gas3-b
-		distance 8021.02
+		distance 38914.3
 		period 8863.78
 		object
 			sprite planet/rock7-b
@@ -488,8 +488,8 @@ system "14 Pole"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 625
-	belt 1881
+	habitable 2266.58
+	belt 7709.37
 	haze _menu/haze-67
 	link "12 Autumn Above"
 	asteroids "small rock" 44 3.904
@@ -522,19 +522,19 @@ system "14 Pole"
 		period 10
 	object
 		sprite planet/desert2
-		distance 187.36
+		distance 598.11
 		period 41.0332
 	object
 		sprite planet/lava4
-		distance 420.45
+		distance 1461.02
 		period 137.94
 	object "Remote Blue"
 		sprite planet/earth
-		distance 658.54
+		distance 2401.83
 		period 270.392
 	object
 		sprite planet/neptune
-		distance 1097.38
+		distance 4233.63
 		period 581.642
 		object
 			sprite planet/dust7-b
@@ -542,7 +542,7 @@ system "14 Pole"
 			period 15.5974
 	object
 		sprite planet/gas1
-		distance 2169.47
+		distance 9037.1
 		period 1616.78
 
 system "14 Summer Above"
@@ -550,8 +550,8 @@ system "14 Summer Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1400
-	belt 1093
+	habitable 5549.99
+	belt 4214.86
 	haze _menu/haze-67
 	link "3 Pole"
 	link "4 Summer Rising"
@@ -580,16 +580,16 @@ system "14 Summer Above"
 	fleet Heliarch 1200
 	object
 		sprite star/g0
-		distance 20.8
+		distance 53.59
 		period 9.28022
 		offset 180
 	object
 		sprite star/m0
-		distance 70.2
+		distance 203.03
 		period 9.28022
 	object
 		sprite planet/gas4-b
-		distance 605.45
+		distance 2188.12
 		period 159.262
 		object
 			sprite planet/rock7
@@ -601,15 +601,15 @@ system "14 Summer Above"
 			period 26.9553
 	object "Second Viridian"
 		sprite planet/forest5-b
-		distance 1256.26
+		distance 4920.14
 		period 476.009
 	object
 		sprite planet/rock0-b
-		distance 1431.1
+		distance 5687.28
 		period 578.763
 	object
 		sprite planet/gas8
-		distance 2256.26
+		distance 9440.78
 		period 1145.72
 
 system "14 Winter Below"
@@ -617,8 +617,8 @@ system "14 Winter Below"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1111.68
-	belt 1173
+	habitable 4294.97
+	belt 4559.04
 	link "8 Winter Below"
 	link "Ki War Ek"
 	link "4 Axis"
@@ -649,36 +649,36 @@ system "14 Winter Below"
 	fleet Heliarch 200
 	object
 		sprite star/g5
-		distance 45.0921
+		distance 124.93
 		period 12.5408
 		offset 180
 	object
 		sprite star/k0
-		distance 57.9079
+		distance 164.36
 		period 12.5408
 	object
 		sprite planet/dust1
-		distance 173.548
+		distance 549.67
 		period 27.4283
 	object
 		sprite planet/ice4
-		distance 504.388
+		distance 1787.25
 		period 135.899
 	object "Midway Emerald"
 		sprite planet/forest1-b
-		distance 917.748
+		distance 3471.23
 		period 333.546
 	object
 		sprite planet/gas4
-		distance 1422.56
+		distance 5649.55
 		period 643.687
 	object
 		sprite planet/gas8
-		distance 1838.32
+		distance 7514.87
 		period 945.586
 	object
 		sprite planet/gas5-b
-		distance 2600.32
+		distance 11058.58
 		period 1590.78
 		object
 			sprite planet/desert4-b
@@ -694,8 +694,8 @@ system "16 Autumn Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1715
-	belt 1424
+	habitable 6955.87
+	belt 5655.91
 	link "12 Autumn Above"
 	link "5 Summer Above"
 	link "11 Autumn Above"
@@ -729,11 +729,11 @@ system "16 Autumn Rising"
 		period 10
 	object
 		sprite planet/rhea-b
-		distance 155.04
+		distance 485.42
 		period 18.6463
 	object
 		sprite planet/cloud8-b
-		distance 494.88
+		distance 1749.97
 		period 106.335
 		object
 			sprite planet/io
@@ -741,7 +741,7 @@ system "16 Autumn Rising"
 			period 24.2278
 	object
 		sprite planet/gas6-b
-		distance 1700.84
+		distance 6891.98
 		period 677.522
 		object
 			sprite planet/ice8-b
@@ -765,8 +765,8 @@ system "3 Axis"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 2372.76
-	belt 1202
+	habitable 9985.52
+	belt 4684.49
 	link "1 Axis"
 	link "8 Winter Below"
 	link "4 Winter Rising"
@@ -802,23 +802,23 @@ system "3 Axis"
 		period 10
 	object
 		sprite planet/desert2-b
-		distance 176.76
+		distance 560.9
 		period 19.2979
 	object
 		sprite planet/dust6-b
-		distance 424.05
+		distance 1474.87
 		period 71.7065
 	object
 		sprite planet/rock3-b
-		distance 719.34
+		distance 2648.97
 		period 158.429
 	object
 		sprite planet/ice0
-		distance 1340.63
+		distance 5288.89
 		period 403.085
 	object
 		sprite planet/gas6
-		distance 2384.92
+		distance 10042.56
 		period 956.409
 		object "Ashy Reach"
 			sprite planet/rock14
@@ -834,8 +834,8 @@ system "3 Pole"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 625
-	belt 1617
+	habitable 2266.58
+	belt 6514.97
 	link "16 Autumn Rising"
 	link "5 Summer Above"
 	link "14 Summer Above"
@@ -871,15 +871,15 @@ system "3 Pole"
 		period 10
 	object
 		sprite planet/rock11-b
-		distance 145.21
+		distance 451.62
 		period 27.9972
 	object "Brass Second"
 		sprite planet/forest6
-		distance 541.22
+		distance 1932.39
 		period 201.456
 	object
 		sprite planet/jupiter
-		distance 955.31
+		distance 3629.34
 		period 472.429
 		object
 			sprite planet/miranda
@@ -887,7 +887,7 @@ system "3 Pole"
 			period 13.3264
 	object
 		sprite planet/tethys-b
-		distance 2014.75
+		distance 8322.21
 		period 1446.94
 
 system "3 Spring Rising"
@@ -895,8 +895,8 @@ system "3 Spring Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1080
-	belt 1613
+	habitable 4159.2
+	belt 6497.04
 	haze _menu/haze-33
 	link "4 Spring Rising"
 	asteroids "small rock" 66 4.9761
@@ -929,23 +929,23 @@ system "3 Spring Rising"
 		period 10
 	object
 		sprite planet/rock8
-		distance 207.41
+		distance 669.1
 		period 36.3574
 	object
 		sprite planet/rock2
-		distance 405.9
+		distance 1405.17
 		period 99.5352
 	object
 		sprite planet/cloud3
-		distance 672.74
+		distance 2459.33
 		period 212.383
 	object "Fourth Shadow"
 		sprite planet/ocean8
-		distance 1272.23
+		distance 4989.73
 		period 552.327
 	object
 		sprite planet/gas4-b
-		distance 3747.48
+		distance 16624.05
 		period 2792.27
 		object
 			sprite planet/oberon-b
@@ -969,8 +969,8 @@ system "4 Axis"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 425.92
-	belt 1838
+	habitable 1482.07
+	belt 7513.41
 	link "14 Winter Below"
 	link "5 Axis"
 	link "5 Spring Below"
@@ -1005,23 +1005,23 @@ system "4 Axis"
 		period 10
 	object
 		sprite planet/lava7-b
-		distance 220.36
+		distance 715.36
 		period 63.4009
 	object "Rusty Second"
 		sprite planet/desert2
-		distance 415.77
+		distance 1443.03
 		period 164.314
 	object
 		sprite planet/rhea-b
-		distance 615.78
+		distance 2229.54
 		period 296.165
 	object
 		sprite planet/rock17-b
-		distance 1455.02
+		distance 5793.12
 		period 1075.72
 	object
 		sprite planet/gas1
-		distance 1864.98
+		distance 7636.3
 		period 1561.02
 		object
 			sprite planet/rock0-b
@@ -1033,8 +1033,8 @@ system "4 Spring Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 320
-	belt 1801
+	habitable 1080.19
+	belt 7345.22
 	link "1 Axis"
 	link "3 Spring Rising"
 	link "11 Spring Below"
@@ -1067,7 +1067,7 @@ system "4 Spring Rising"
 		period 10
 	object "Blue Interior"
 		sprite planet/ocean7
-		distance 375.04
+		distance 1287.45
 		period 162.406
 		object
 			sprite planet/io-b
@@ -1075,15 +1075,15 @@ system "4 Spring Rising"
 			period 25.0209
 	object
 		sprite planet/lava6
-		distance 728.48
+		distance 2686.33
 		period 439.654
 	object
 		sprite planet/gas9-b
-		distance 1359.69
+		distance 5372.57
 		period 1121.1
 	object
 		sprite planet/gas2
-		distance 2599.94
+		distance 11056.77
 		period 2964.35
 		object
 			sprite planet/luna-b
@@ -1099,8 +1099,8 @@ system "4 Summer Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 320
-	belt 1860
+	habitable 1080.19
+	belt 7613.6
 	link "3 Pole"
 	link "14 Summer Above"
 	asteroids "small rock" 7 3.1694
@@ -1132,27 +1132,27 @@ system "4 Summer Rising"
 		period 10
 	object
 		sprite planet/rock2
-		distance 153.49
+		distance 480.07
 		period 42.5212
 	object "Double Haze"
 		sprite planet/titan
-		distance 369.65
+		distance 1266.99
 		period 158.917
 	object
 		sprite planet/rock15
-		distance 571.9
+		distance 2054.14
 		period 305.819
 	object
 		sprite planet/desert3-b
-		distance 1413.15
+		distance 5608.0
 		period 1187.87
 	object
 		sprite planet/desert9-b
-		distance 1614.64
+		distance 6504.39
 		period 1450.77
 	object
 		sprite planet/jupiter-b
-		distance 3944.64
+		distance 17603.31
 		period 5539.83
 
 system "4 Winter Rising"
@@ -1160,8 +1160,8 @@ system "4 Winter Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 135
-	belt 1345
+	habitable 416.76
+	belt 5308.06
 	link "Sol Kimek"
 	link "1 Axis"
 	link "5 Winter Above"
@@ -1196,19 +1196,19 @@ system "4 Winter Rising"
 		period 10
 	object "Inmost Blue"
 		sprite planet/ocean5
-		distance 154.25
+		distance 482.69
 		period 65.9524
 	object
 		sprite planet/cloud6
-		distance 372.09
+		distance 1276.25
 		period 247.096
 	object
 		sprite planet/rock4
-		distance 699.1
+		distance 2566.43
 		period 636.359
 	object
 		sprite planet/gas10-b
-		distance 1598.39
+		distance 6431.59
 		period 2199.97
 		object
 			sprite planet/dust1
@@ -1216,7 +1216,7 @@ system "4 Winter Rising"
 			period 14.7767
 	object
 		sprite planet/gas15-b
-		distance 3078.4
+		distance 13348.48
 		period 5880.05
 		object
 			sprite planet/dust5-b
@@ -1236,8 +1236,8 @@ system "5 Axis"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 233.28
-	belt 1775
+	habitable 761.8
+	belt 7227.28
 	link "4 Axis"
 	link "Ki War Ek"
 	asteroids "small rock" 6 3.3264
@@ -1270,23 +1270,23 @@ system "5 Axis"
 		period 10
 	object
 		sprite planet/rock11
-		distance 125.25
+		distance 383.74
 		period 36.7103
 	object "Second Cerulean"
 		sprite planet/ocean6
-		distance 345.69
+		distance 1176.48
 		period 168.326
 	object
 		sprite planet/oberon
-		distance 532.53
+		distance 1898.04
 		period 321.838
 	object
 		sprite planet/cloud7-b
-		distance 893.69
+		distance 3370.34
 		period 699.683
 	object
 		sprite planet/gas17
-		distance 1685.05
+		distance 6820.81
 		period 1811.51
 		object
 			sprite planet/ice8
@@ -1310,8 +1310,8 @@ system "5 Spring Below"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1313.28
-	belt 1104
+	habitable 5169.05
+	belt 4262.02
 	link "4 Axis"
 	link "11 Spring Below"
 	asteroids "small rock" 77 6.0372
@@ -1342,20 +1342,20 @@ system "5 Spring Below"
 	fleet Heliarch 500
 	object
 		sprite star/g0-old
-		distance 19.7171
+		distance 50.55
 		period 12.9082
 		offset 180
 	object
 		sprite star/m4
-		distance 91.2829
+		distance 270.94
 		period 12.9082
 	object
 		sprite planet/dust6
-		distance 235.643
+		distance 770.32
 		period 39.9266
 	object
 		sprite planet/gas12
-		distance 863.853
+		distance 3245.66
 		period 280.247
 		object
 			sprite planet/europa-b
@@ -1363,11 +1363,11 @@ system "5 Spring Below"
 			period 13.4437
 	object
 		sprite planet/desert10
-		distance 1349.01
+		distance 5325.66
 		period 546.897
 	object
 		sprite planet/gas10-b
-		distance 2098.65
+		distance 8709.1
 		period 1061.19
 		object
 			sprite planet/miranda-b
@@ -1383,8 +1383,8 @@ system "5 Summer Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 425.92
-	belt 1133
+	habitable 1482.07
+	belt 4386.6
 	haze _menu/haze-133
 	link "16 Autumn Rising"
 	link "3 Pole"
@@ -1419,23 +1419,23 @@ system "5 Summer Above"
 		period 10
 	object
 		sprite planet/rhea
-		distance 152.21
+		distance 475.66
 		period 36.3966
 	object "Nearby Jade"
 		sprite planet/forest2
-		distance 410.9
+		distance 1424.34
 		period 161.436
 	object
 		sprite planet/titan-b
-		distance 664.19
+		distance 2424.69
 		period 331.768
 	object
 		sprite planet/desert8-b
-		distance 1035.4
+		distance 3968.82
 		period 645.741
 	object
 		sprite planet/gas14
-		distance 1579.64
+		distance 6347.7
 		period 1216.84
 		object
 			sprite planet/europa-b
@@ -1443,7 +1443,7 @@ system "5 Summer Above"
 			period 12.8386
 	object
 		sprite planet/gas3-b
-		distance 2585.48
+		distance 10988.25
 		period 2548.05
 
 system "5 Winter Above"
@@ -1451,8 +1451,8 @@ system "5 Winter Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 320
-	belt 1414
+	habitable 1080.19
+	belt 5611.75
 	link "4 Winter Rising"
 	asteroids "small rock" 24 3.276
 	asteroids "medium rock" 33 2.1672
@@ -1484,7 +1484,7 @@ system "5 Winter Above"
 		period 10
 	object "Into White"
 		sprite planet/ice1
-		distance 357.96
+		distance 1222.75
 		period 151.439
 		object
 			sprite planet/ice0-b
@@ -1492,19 +1492,19 @@ system "5 Winter Above"
 			period 20.126
 	object
 		sprite planet/ganymede-b
-		distance 797.17
+		distance 2968.79
 		period 503.282
 	object
 		sprite planet/lava3
-		distance 1312.86
+		distance 5167.21
 		period 1063.68
 	object
 		sprite planet/jupiter-b
-		distance 1764.7
+		distance 7180.61
 		period 1657.64
 	object
 		sprite planet/gas2-b
-		distance 2494.95
+		distance 10560.26
 		period 2786.62
 		object
 			sprite planet/io-b
@@ -1516,8 +1516,8 @@ system "7 Autumn Rising"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 425.92
-	belt 1289
+	habitable 1482.07
+	belt 5062.9
 	link "11 Autumn Above"
 	asteroids "small rock" 7 1.463
 	asteroids "medium rock" 7 0.638
@@ -1547,23 +1547,23 @@ system "7 Autumn Rising"
 		period 10
 	object
 		sprite planet/ice6
-		distance 152.76
+		distance 477.56
 		period 36.594
 	object "Sandy Two"
 		sprite planet/desert9
-		distance 447.8
+		distance 1566.59
 		period 183.663
 	object
 		sprite planet/gas0
-		distance 1034.05
+		distance 3963.07
 		period 644.478
 	object
 		sprite planet/uranus-b
-		distance 1475.74
+		distance 5884.96
 		period 1098.78
 	object
 		sprite planet/gas2-b
-		distance 2223.3
+		distance 9287.25
 		period 2031.86
 		object
 			sprite planet/dust3
@@ -1583,8 +1583,8 @@ system "8 Winter Below"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 486.68
-	belt 1285
+	habitable 1717.88
+	belt 5045.44
 	link "3 Axis"
 	link "14 Winter Below"
 	asteroids "small rock" 25 1.4256
@@ -1617,11 +1617,11 @@ system "8 Winter Below"
 		period 10
 	object
 		sprite planet/dust6
-		distance 172.25
+		distance 545.14
 		period 40.9899
 	object "Dusk Companion"
 		sprite planet/rock19
-		distance 665.46
+		distance 2429.83
 		period 311.258
 		object
 			sprite planet/rock3-b
@@ -1629,11 +1629,11 @@ system "8 Winter Below"
 			period 26.0401
 	object
 		sprite planet/gas7
-		distance 1368.07
+		distance 5409.4
 		period 917.489
 	object
 		sprite planet/gas16-b
-		distance 3048.07
+		distance 13201.87
 		period 3051.23
 		object
 			sprite planet/io
@@ -1649,8 +1649,8 @@ system "9 Spring Above"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 1050.92
-	belt 1397
+	habitable 4034.96
+	belt 5536.77
 	haze _menu/haze-67
 	link "Sol Kimek"
 	asteroids "medium rock" 37 4.07
@@ -1680,36 +1680,36 @@ system "9 Spring Above"
 	fleet Heliarch 700
 	object
 		sprite star/g5
-		distance 42.1494
+		distance 116.03
 		period 13.0866
 	object
 		sprite star/k5
-		distance 61.8506
+		distance 176.68
 		period 13.0866
 		offset 180
 	object
 		sprite planet/ice1-b
-		distance 234.461
+		distance 766.06
 		period 44.2976
 	object
 		sprite planet/rock5
-		distance 450.461
+		distance 1576.9
 		period 117.967
 	object
 		sprite planet/lava6
-		distance 688.711
+		distance 2524.16
 		period 223.013
 	object "Turquoise Four"
 		sprite planet/water1
-		distance 925.521
+		distance 3503.88
 		period 347.42
 	object
 		sprite planet/gas3
-		distance 1763.76
+		distance 7176.35
 		period 913.976
 	object
 		sprite planet/gas5
-		distance 2550
+		distance 10820.3
 		period 1588.86
 		object
 			sprite planet/europa
@@ -1725,8 +1725,8 @@ system Ablodab
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 425.92
-	belt 1368
+	habitable 1482.07
+	belt 5409.09
 	link Debrugt
 	link Gupta
 	link Pelubta
@@ -1757,15 +1757,15 @@ system Ablodab
 		period 10
 	object
 		sprite planet/desert7-b
-		distance 185
+		distance 589.81
 		period 48.7701
 	object
 		sprite planet/desert2-b
-		distance 514.56
+		distance 1827.22
 		period 226.23
 	object
 		sprite planet/gas5
-		distance 1141.05
+		distance 4421.25
 		period 747.056
 		object
 			sprite planet/tethys-b
@@ -1773,11 +1773,11 @@ system Ablodab
 			period 14.1834
 	object
 		sprite planet/cloud5
-		distance 1754.3
+		distance 7133.52
 		period 1424.14
 	object
 		sprite planet/gas1-b
-		distance 4998.14
+		distance 22930.18
 		period 6848.71
 		object
 			sprite planet/dust1
@@ -1801,8 +1801,8 @@ system Ablub
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 233.28
-	belt 1641
+	habitable 761.8
+	belt 6622.67
 	haze _menu/haze-133
 	link Blubipad
 	link Miblulub
@@ -1836,19 +1836,19 @@ system Ablub
 		period 10
 	object "Ablub's Invention"
 		sprite planet/forest1-b
-		distance 203.76
+		distance 656.12
 		period 76.1728
 	object
 		sprite planet/cloud0-b
-		distance 419.76
+		distance 1458.37
 		period 225.228
 	object
 		sprite planet/rock8
-		distance 714.8
+		distance 2630.43
 		period 500.493
 	object
 		sprite planet/gas5
-		distance 1929.89
+		distance 7932.81
 		period 2220.34
 
 system Acamar
@@ -1856,8 +1856,8 @@ system Acamar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1080
-	belt 1013
+	habitable 4159.2
+	belt 3873.56
 	link Diphda
 	link Aldebaran
 	link Elnath
@@ -1888,15 +1888,15 @@ system Acamar
 		period 10
 	object
 		sprite planet/lava2-b
-		distance 174.69
+		distance 553.66
 		period 28.1028
 	object
 		sprite planet/ice0
-		distance 396.53
+		distance 1369.32
 		period 96.1086
 	object
 		sprite planet/rock9-b
-		distance 798.37
+		distance 2973.75
 		period 274.571
 		object
 			sprite planet/dust7
@@ -1904,11 +1904,11 @@ system Acamar
 			period 20.7539
 	object
 		sprite planet/cloud1
-		distance 1350.62
+		distance 5332.73
 		period 604.154
 	object
 		sprite planet/dust3-b
-		distance 4090.18
+		distance 18329.98
 		period 3183.92
 
 system Achernar
@@ -1916,8 +1916,8 @@ system Achernar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1963
+	habitable 2266.58
+	belt 8084.51
 	haze _menu/haze-133
 	link "Al Dhanab"
 	link Alpheratz
@@ -1949,11 +1949,11 @@ system Achernar
 		period 10
 	object
 		sprite planet/desert3
-		distance 211.24
+		distance 682.75
 		period 49.1229
 	object Foundry
 		sprite planet/forest1-b
-		distance 548
+		distance 1959.23
 		period 205.254
 		object
 			sprite planet/miranda-b
@@ -1961,19 +1961,19 @@ system Achernar
 			period 15.4433
 	object
 		sprite planet/dust0
-		distance 978.21
+		distance 3726.08
 		period 489.517
 	object
 		sprite planet/titan-b
-		distance 1311.9
+		distance 5163.01
 		period 760.276
 	object
 		sprite planet/ice8
-		distance 1664.39
+		distance 6727.8
 		period 1086.43
 	object
 		sprite planet/neptune
-		distance 3673.43
+		distance 16257.83
 		period 3562.28
 		object
 			sprite planet/lava0
@@ -1989,8 +1989,8 @@ system Acrux
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 590.625
-	belt 1407
+	habitable 2128.81
+	belt 5580.86
 	haze _menu/haze-67
 	link Minkar
 	link "Zeta Centauri"
@@ -2021,32 +2021,32 @@ system Acrux
 	fleet "Human Miners" 5000
 	object
 		sprite star/k0
-		distance 17.9429
+		distance 45.61
 		period 11.4474
 	object
 		sprite star/m4
-		distance 60.5571
+		distance 172.63
 		period 11.4474
 		offset 180
 	object
 		sprite planet/gas2-hot
-		distance 249.567
+		distance 820.74
 		period 64.8911
 	object Starcross
 		sprite planet/cloud2
-		distance 540.407
+		distance 1929.17
 		period 206.769
 	object
 		sprite planet/luna
-		distance 1010.57
+		distance 3863.24
 		period 528.752
 	object
 		sprite planet/rock13
-		distance 1587.57
+		distance 6383.17
 		period 1041.12
 	object
 		sprite planet/gas6
-		distance 3849.21
+		distance 17128.58
 		period 3930.62
 		object
 			sprite planet/desert4
@@ -2070,8 +2070,8 @@ system Adhara
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 670
-	belt 1014
+	habitable 2448.22
+	belt 3877.81
 	link "Epsilon Leonis"
 	link Gomeisa
 	asteroids "small rock" 5 3.705
@@ -2099,20 +2099,20 @@ system Adhara
 	fleet "Small Northern Pirates" 2000
 	object
 		sprite star/k0
-		distance 33.5961
+		distance 90.51
 		period 16.6267
 	object
 		sprite star/m0
-		distance 71.4039
+		distance 206.85
 		period 16.6267
 		offset 180
 	object
 		sprite planet/desert6-b
-		distance 279.714
+		distance 930.92
 		period 72.2926
 	object Muspel
 		sprite planet/mars
-		distance 638.124
+		distance 2319.41
 		period 249.104
 		object Norn
 			sprite planet/ice7
@@ -2120,15 +2120,15 @@ system Adhara
 			period 20.6008
 	object
 		sprite planet/cloud7-b
-		distance 1033.48
+		distance 3960.65
 		period 513.426
 	object
 		sprite planet/dust1
-		distance 1498.37
+		distance 5985.43
 		period 896.299
 	object
 		sprite planet/oberon
-		distance 2411.01
+		distance 10165.06
 		period 1829.46
 
 system Aescolanus
@@ -2136,8 +2136,8 @@ system Aescolanus
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 233.28
-	belt 1323
+	habitable 761.8
+	belt 5211.6
 	haze _menu/haze-red
 	trade Clothing 262
 	trade Electronics 835
@@ -2156,23 +2156,23 @@ system Aescolanus
 		period 10
 	object
 		sprite planet/desert4
-		distance 111.24
+		distance 336.77
 		period 30.7265
 	object
 		sprite planet/dust3-b
-		distance 308.68
+		distance 1038.03
 		period 142.031
 	object
 		sprite planet/gas8
-		distance 636.84
+		distance 2314.23
 		period 420.888
 	object
 		sprite planet/desert9-b
-		distance 912.88
+		distance 3450.79
 		period 722.34
 	object "Ember Wormhole"
 		sprite planet/wormhole-red
-		distance 2279.29
+		distance 9548.2
 		period 2849.84
 
 system "Aki'il"
@@ -2180,7 +2180,7 @@ system "Aki'il"
 	government Uninhabited
 	attributes "ember waste" "graveyard"
 	arrival 1500
-	habitable 1505.92
+	habitable 6018.99
 	asteroids "large metal" 47 5
 	asteroids "large rock" 2 10
 	asteroids "medium metal" 100 8
@@ -2199,36 +2199,36 @@ system "Aki'il"
 	trade Plastic 286
 	object
 		sprite star/g0-old
-		distance 32.2427
+		distance 86.53
 		period 12.5463
 	object
 		sprite star/k5
-		distance 81.7573
+		distance 240.03
 		period 12.5463
 		offset 180
 	object
 		sprite planet/rock7
-		distance 1209.76
+		distance 4718.12
 		period 433.717
 		offset 29.5665
 	object
 		sprite planet/rock18
-		distance 252.757
+		distance 832.33
 		period 41.4204
 		offset 61.3079
 	object
 		sprite planet/neptune
-		distance 2740.76
+		distance 11726.45
 		period 1478.99
 		offset 9.66291
 	object
 		sprite planet/desert7
-		distance 600.757
+		distance 2169.33
 		period 151.778
 		offset 57.1944
 	object "Kaeyin"
 		sprite planet/ocean3
-		distance 927.757
+		distance 3513.29
 		period 291.28
 		offset 4.23336
 
@@ -2237,8 +2237,8 @@ system "Al Dhanab"
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1080
-	belt 1432
+	habitable 4159.2
+	belt 5691.26
 	haze _menu/haze-133
 	link Scheat
 	link Mirach
@@ -2276,7 +2276,7 @@ system "Al Dhanab"
 		period 10
 	object
 		sprite planet/ice5
-		distance 364
+		distance 1245.59
 		period 84.5279
 		object
 			sprite planet/dust4-b
@@ -2284,11 +2284,11 @@ system "Al Dhanab"
 			period 17.5128
 	object Burthen
 		sprite planet/forest0
-		distance 874.25
+		distance 3289.05
 		period 314.631
 	object
 		sprite planet/ocean4
-		distance 1488.34
+		distance 5940.88
 		period 698.878
 		object
 			sprite planet/rock17
@@ -2296,11 +2296,11 @@ system "Al Dhanab"
 			period 17.1813
 	object
 		sprite planet/rock3
-		distance 1931.34
+		distance 7939.45
 		period 1033.09
 	object
 		sprite planet/luna
-		distance 2298.15
+		distance 9636.28
 		period 1340.96
 
 system Albaldah
@@ -2308,8 +2308,8 @@ system Albaldah
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 534.375
-	belt 1622
+	habitable 1905.33
+	belt 6537.4
 	haze _menu/haze-133
 	link Albireo
 	link Girtab
@@ -2343,28 +2343,28 @@ system Albaldah
 	fleet "Human Miners" 3000
 	object
 		sprite star/k5
-		distance 42.7246
+		distance 117.76
 		period 19.0178
 		offset 180
 	object
 		sprite star/m0
-		distance 63.7754
+		distance 182.72
 		period 19.0178
 	object
 		sprite planet/ice6
-		distance 261.435
+		distance 863.95
 		period 73.1448
 	object "New India"
 		sprite planet/ocean2
-		distance 517.075
+		distance 1837.11
 		period 203.455
 	object
 		sprite planet/tethys
-		distance 768.685
+		distance 2851.31
 		period 368.774
 	object
 		sprite planet/gas16-b
-		distance 1670.9
+		distance 6757.1
 		period 1181.85
 		object
 			sprite planet/lava1-b
@@ -2372,7 +2372,7 @@ system Albaldah
 			period 14.3618
 	object
 		sprite planet/uranus-b
-		distance 3405.54
+		distance 14940.44
 		period 3438.86
 		object
 			sprite planet/luna
@@ -2384,8 +2384,8 @@ system Albireo
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 760
-	belt 1030
+	habitable 2815.59
+	belt 3945.83
 	link Tarazed
 	link Albaldah
 	link Sadr
@@ -2414,28 +2414,28 @@ system Albireo
 	fleet Quarg 2000
 	object
 		sprite star/g5
-		distance 15.6316
+		distance 39.24
 		period 11.9778
 	object
 		sprite star/m4
-		distance 72.3684
+		distance 209.92
 		period 11.9778
 		offset 180
 	object
 		sprite planet/desert9
-		distance 258.368
+		distance 852.76
 		period 60.2577
 	object
 		sprite planet/cloud8-b
-		distance 494.928
+		distance 1750.16
 		period 159.76
 	object Sinter
 		sprite planet/rock9
-		distance 801.738
+		distance 2987.67
 		period 329.384
 	object
 		sprite planet/ice8-b
-		distance 2211.99
+		distance 9234.63
 		period 1509.48
 
 system Alcyone
@@ -2443,8 +2443,8 @@ system Alcyone
 	government Pirate
 	attributes "core"
 	arrival 1500
-	habitable 270
-	belt 1438
+	habitable 895.27
+	belt 5717.79
 	haze _menu/haze-133
 	link Zaurak
 	link Oblate
@@ -2470,20 +2470,20 @@ system Alcyone
 	fleet "Large Syndicate" 1200
 	object
 		sprite star/m4
-		distance 45.5
+		distance 126.17
 		period 21.132
 		offset 180
 	object
 		sprite star/m4
-		distance 45.5
+		distance 126.17
 		period 21.132
 	object Stormhold
 		sprite planet/ocean0
-		distance 302.91
+		distance 1016.6
 		period 128.336
 	object
 		sprite planet/gas4-b
-		distance 894.47
+		distance 3373.61
 		period 651.219
 		object
 			sprite planet/ice7
@@ -2491,11 +2491,11 @@ system Alcyone
 			period 13.5253
 	object
 		sprite planet/rock13
-		distance 1855.03
+		distance 7590.96
 		period 1944.93
 	object
 		sprite planet/neptune-b
-		distance 3456.59
+		distance 15190.56
 		period 4947.09
 		object
 			sprite planet/rock0-b
@@ -2511,8 +2511,8 @@ system Aldebaran
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 625
-	belt 1296
+	habitable 2266.58
+	belt 5093.48
 	link Capella
 	link Acamar
 	link Elnath
@@ -2538,19 +2538,19 @@ system Aldebaran
 		period 10
 	object
 		sprite planet/cloud6-b
-		distance 165.81
+		distance 522.71
 		period 34.1614
 	object Ada
 		sprite planet/forest2-b
-		distance 549.02
+		distance 1963.27
 		period 205.827
 	object
 		sprite planet/rock6-b
-		distance 1174.58
+		distance 4565.87
 		period 644.086
 	object
 		sprite planet/dust7-b
-		distance 2128.22
+		distance 8845.9
 		period 1570.89
 
 system Alderamin
@@ -2558,8 +2558,8 @@ system Alderamin
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1705
-	belt 1908
+	habitable 6910.75
+	belt 7832.68
 	haze _menu/haze-133
 	link Alnair
 	link "Delta Capricorni"
@@ -2587,24 +2587,24 @@ system Alderamin
 	fleet "Large Core Pirates" 1200
 	object
 		sprite star/g0
-		distance 36.6569
+		distance 99.58
 		period 9.68719
 	object
 		sprite star/g5
-		distance 63.3431
+		distance 181.36
 		period 9.68719
 		offset 180
 	object
 		sprite planet/desert7
-		distance 258.593
+		distance 853.58
 		period 40.2831
 	object
 		sprite planet/venus
-		distance 502.283
+		distance 1778.99
 		period 109.049
 	object
 		sprite planet/cloud0
-		distance 1072.52
+		distance 4127.2
 		period 340.258
 		object Furnace
 			sprite planet/dust4
@@ -2612,11 +2612,11 @@ system Alderamin
 			period 21.8072
 	object
 		sprite planet/miranda
-		distance 1670.52
+		distance 6755.39
 		period 661.419
 	object
 		sprite planet/gas0-b
-		distance 2301.76
+		distance 9653.14
 		period 1069.77
 
 system Aldhibain
@@ -2624,8 +2624,8 @@ system Aldhibain
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 455.625
-	belt 1840
+	habitable 1596.92
+	belt 7522.51
 	link Kornephoros
 	link Sabik
 	link Alniyat
@@ -2661,19 +2661,19 @@ system Aldhibain
 		period 10
 	object
 		sprite planet/desert10
-		distance 162.5
+		distance 511.22
 		period 38.8183
 	object Glaze
 		sprite planet/ocean2
-		distance 449.59
+		distance 1573.52
 		period 178.641
 	object
 		sprite planet/desert7
-		distance 779.2
+		distance 2894.62
 		period 407.596
 	object
 		sprite planet/neptune-b
-		distance 2197.61
+		distance 9167.78
 		period 1930.55
 		object "Charon Station"
 			sprite planet/station14
@@ -2685,8 +2685,8 @@ system Algenib
 	pos -118 341
 	government Pirate
 	arrival 1500
-	habitable 455.625
-	belt 1273
+	habitable 1596.92
+	belt 4993.08
 	link Gienah
 	asteroids "large metal" 1 6.7392
 	trade Clothing 357
@@ -2707,7 +2707,7 @@ system Algenib
 		period 10
 	object "Buccaneer Bay"
 		sprite planet/ocean6
-		distance 267.91
+		distance 887.62
 		period 82.175
 		object
 			sprite planet/dust7-b
@@ -2715,15 +2715,15 @@ system Algenib
 			period 13.5253
 	object
 		sprite planet/ice7
-		distance 579.92
+		distance 2086.09
 		period 261.703
 	object
 		sprite planet/callisto-b
-		distance 887.96
+		distance 3346.36
 		period 495.845
 	object
 		sprite planet/gas14
-		distance 2108.2
+		distance 8753.26
 		period 1813.94
 		object
 			sprite planet/rock0
@@ -2743,8 +2743,8 @@ system Algieba
 	pos -691 -52
 	government Republic
 	arrival 1500
-	habitable 2695
-	belt 1070
+	habitable 11508.38
+	belt 4116.43
 	link "Tania Australis"
 	link Alphard
 	link Zosma
@@ -2773,32 +2773,32 @@ system Algieba
 	fleet "Large Northern Merchants" 600
 	object
 		sprite star/f0
-		distance 5.86085
+		distance 13.5
 		period 9.75123
 	object
 		sprite star/m4
-		distance 111.139
+		distance 336.43
 		period 9.75123
 		offset 180
 	object
 		sprite planet/ice8-b
-		distance 266.779
+		distance 883.48
 		period 33.5744
 	object
 		sprite planet/dust1
-		distance 495.669
+		distance 1753.06
 		period 85.0293
 	object
 		sprite planet/dust3-b
-		distance 712.919
+		distance 2622.76
 		period 146.67
 	object
 		sprite planet/forest0-b
-		distance 1363.17
+		distance 5387.86
 		period 387.798
 	object
 		sprite planet/gas4
-		distance 3147.93
+		distance 13685.22
 		period 1360.87
 		object
 			sprite planet/rock7
@@ -2814,8 +2814,8 @@ system Algol
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 534.375
-	belt 1839
+	habitable 1905.33
+	belt 7517.96
 	haze _menu/haze-133
 	link Ruchbah
 	asteroids "large metal" 1 1.35
@@ -2836,28 +2836,28 @@ system Algol
 	fleet "Small Syndicate" 2400
 	object
 		sprite star/k5-old
-		distance 42.7246
+		distance 117.76
 		period 19.0178
 	object
 		sprite star/m0
-		distance 63.7754
+		distance 182.72
 		period 19.0178
 		offset 180
 	object
 		sprite planet/desert6
-		distance 336.885
+		distance 1143.38
 		period 106.994
 	object Quicksilver
 		sprite planet/ocean9
-		distance 599.175
+		distance 2162.99
 		period 253.786
 	object
 		sprite planet/desert4-b
-		distance 1101.87
+		distance 4252.88
 		period 632.892
 	object
 		sprite planet/uranus
-		distance 2249.12
+		distance 9407.5
 		period 1845.67
 		object
 			sprite planet/io-b
@@ -2877,8 +2877,8 @@ system Algorel
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1993
+	habitable 1080.19
+	belt 8222.22
 	haze _menu/haze-67
 	link "Cor Caroli"
 	link Turais
@@ -2911,7 +2911,7 @@ system Algorel
 		period 10
 	object "New Wales"
 		sprite planet/cloud6
-		distance 275.25
+		distance 914.52
 		period 102.112
 		object
 			sprite planet/rock17-b
@@ -2919,7 +2919,7 @@ system Algorel
 			period 16.6972
 	object
 		sprite planet/gas14-b
-		distance 1107.49
+		distance 4276.99
 		period 824.128
 		object
 			sprite planet/tethys-b
@@ -2931,7 +2931,7 @@ system Algorel
 			period 27.1957
 	object
 		sprite planet/gas13
-		distance 1859.58
+		distance 7611.69
 		period 1793.11
 		object "Hydra Station"
 			sprite planet/station13
@@ -2943,8 +2943,8 @@ system Alheka
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1080
-	belt 1380
+	habitable 4159.2
+	belt 5461.89
 	haze _menu/haze-67
 	link Betelgeuse
 	link Canopus
@@ -2979,19 +2979,19 @@ system Alheka
 		period 10
 	object
 		sprite planet/desert8
-		distance 207.61
+		distance 669.82
 		period 36.41
 	object
 		sprite planet/cloud4-b
-		distance 626.61
+		distance 2273.05
 		period 190.917
 	object Shroud
 		sprite planet/venus
-		distance 947.77
+		distance 3597.54
 		period 355.142
 	object
 		sprite planet/gas13
-		distance 2035.77
+		distance 8418.96
 		period 1118
 		object "Triton Station"
 			sprite planet/station2
@@ -3003,8 +3003,8 @@ system Alhena
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 945
-	belt 1078
+	habitable 3585.87
+	belt 4150.64
 	haze _menu/haze-67
 	link Menkalinan
 	link Wazn
@@ -3033,20 +3033,20 @@ system Alhena
 	fleet "Republic Logistics" 3000
 	object
 		sprite star/g5
-		distance 32.1693
+		distance 86.31
 		period 12.0484
 		offset 180
 	object
 		sprite star/k5
-		distance 62.8307
+		distance 179.75
 		period 12.0484
 	object
 		sprite planet/rock19-b
-		distance 297.521
+		distance 996.63
 		period 66.7759
 	object
 		sprite planet/desert3
-		distance 670.931
+		distance 2452.0
 		period 226.131
 		object
 			sprite planet/ice7
@@ -3054,15 +3054,15 @@ system Alhena
 			period 18.6894
 	object Mainsail
 		sprite planet/ice5
-		distance 1101.93
+		distance 4253.14
 		period 475.966
 	object
 		sprite planet/ice8
-		distance 1500.97
+		distance 5996.99
 		period 756.663
 	object
 		sprite planet/gas13
-		distance 3469.58
+		distance 15254.28
 		period 2659.25
 		object
 			sprite planet/io-b
@@ -3074,8 +3074,8 @@ system Alioth
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 455.625
-	belt 1889
+	habitable 1596.92
+	belt 7745.89
 	link Wei
 	link Vindemiatrix
 	link Alphecca
@@ -3104,15 +3104,15 @@ system Alioth
 		period 10
 	object
 		sprite planet/fog0
-		distance 236.5
+		distance 773.42
 		period 68.1558
 	object "New Tibet"
 		sprite planet/forest1
-		distance 516.34
+		distance 1834.22
 		period 219.867
 	object
 		sprite planet/cloud8-b
-		distance 1370.23
+		distance 5418.9
 		period 950.488
 		object
 			sprite planet/dust3
@@ -3120,7 +3120,7 @@ system Alioth
 			period 20.1302
 	object
 		sprite planet/dust4
-		distance 2197.72
+		distance 9168.29
 		period 1930.7
 
 system Alkaid
@@ -3128,8 +3128,8 @@ system Alkaid
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 1080
-	belt 1142
+	habitable 4159.2
+	belt 4425.34
 	haze _menu/haze-67
 	link Hadar
 	asteroids "medium rock" 7 5.2164
@@ -3157,7 +3157,7 @@ system Alkaid
 		period 10
 	object
 		sprite planet/cloud5
-		distance 363.84
+		distance 1244.98
 		period 84.4722
 		object
 			sprite planet/mercury
@@ -3165,7 +3165,7 @@ system Alkaid
 			period 20.4066
 	object Thunder
 		sprite planet/ocean1
-		distance 934.8
+		distance 3542.91
 		period 347.877
 		object
 			sprite planet/luna
@@ -3173,7 +3173,7 @@ system Alkaid
 			period 22.7102
 	object
 		sprite planet/gas0
-		distance 1927.89
+		distance 7923.65
 		period 1030.32
 		object
 			sprite planet/dust3-b
@@ -3197,8 +3197,8 @@ system Almaaz
 	government Pirate
 	attributes "north"
 	arrival 1500
-	habitable 1080
-	belt 1873
+	habitable 4159.2
+	belt 7672.87
 	haze _menu/haze-33
 	link Hatysa
 	link Mintaka
@@ -3229,15 +3229,15 @@ system Almaaz
 		period 10
 	object
 		sprite planet/rock10-b
-		distance 186.96
+		distance 596.7
 		period 31.1151
 	object
 		sprite planet/ganymede
-		distance 588.37
+		distance 2119.8
 		period 173.71
 	object Freedom
 		sprite planet/cloud2
-		distance 930.93
+		distance 3526.63
 		period 345.719
 
 system Almach
@@ -3245,8 +3245,8 @@ system Almach
 	government Pirate
 	attributes "core"
 	arrival 1500
-	habitable 320
-	belt 1914
+	habitable 1080.19
+	belt 7860.11
 	haze _menu/haze-133
 	link Schedar
 	asteroids "small rock" 105 2.2763
@@ -3277,11 +3277,11 @@ system Almach
 		period 10
 	object
 		sprite planet/desert8
-		distance 197.61
+		distance 634.31
 		period 62.1153
 	object "Deadman's Cove"
 		sprite planet/ocean9
-		distance 639.82
+		distance 2326.24
 		period 361.886
 		object
 			sprite planet/ice8-b
@@ -3289,7 +3289,7 @@ system Almach
 			period 20.8235
 	object
 		sprite planet/jupiter
-		distance 1628.43
+		distance 6566.24
 		period 1469.4
 		object
 			sprite planet/luna-b
@@ -3309,8 +3309,8 @@ system Alnair
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 135
-	belt 1969
+	habitable 416.76
+	belt 8112.03
 	haze _menu/haze-133
 	link Persian
 	link Alderamin
@@ -3343,15 +3343,15 @@ system Alnair
 		period 10
 	object Hippocrates
 		sprite planet/cloud4
-		distance 160.25
+		distance 503.43
 		period 69.8377
 	object
 		sprite planet/lava7-b
-		distance 614.29
+		distance 2223.56
 		period 524.147
 	object
 		sprite planet/gas17-b
-		distance 1355.45
+		distance 5353.94
 		period 1717.98
 		object
 			sprite planet/oberon
@@ -3367,7 +3367,7 @@ system Alnair
 			period 34.3541
 	object
 		sprite planet/gas5-b
-		distance 2418.94
+		distance 10202.33
 		period 4095.72
 		object
 			sprite planet/europa
@@ -3379,8 +3379,8 @@ system Alnasl
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 640
-	belt 1412
+	habitable 2326.97
+	belt 5602.93
 	haze _menu/haze-133
 	link Seginus
 	link Wei
@@ -3410,16 +3410,16 @@ system Alnasl
 	fleet "Small Southern Pirates" 4000
 	object
 		sprite star/k5
-		distance 41.5
+		distance 114.07
 		period 11.956
 		offset 180
 	object
 		sprite star/k5-old
-		distance 41.5
+		distance 114.07
 		period 11.956
 	object
 		sprite planet/gas16-b
-		distance 764.39
+		distance 2833.64
 		period 334.151
 		object
 			sprite planet/lava1-b
@@ -3435,7 +3435,7 @@ system Alnasl
 			period 56.4362
 	object
 		sprite planet/gas3-b
-		distance 1788.8
+		distance 7289.86
 		period 1196.22
 
 system Alnilam
@@ -3443,8 +3443,8 @@ system Alnilam
 	government Pirate
 	attributes "north"
 	arrival 1500
-	habitable 1715
-	belt 1099
+	habitable 6955.87
+	belt 4240.57
 	haze _menu/haze-33
 	link Hatysa
 	asteroids "small rock" 1 2.166
@@ -3474,11 +3474,11 @@ system Alnilam
 		period 10
 	object
 		sprite planet/desert1
-		distance 224.69
+		distance 730.89
 		period 32.5315
 	object
 		sprite planet/gas7-b
-		distance 966.7
+		distance 3677.43
 		period 290.312
 		object
 			sprite planet/miranda-b
@@ -3490,7 +3490,7 @@ system Alnilam
 			period 17.2841
 	object Zenith
 		sprite planet/ocean7
-		distance 1776.59
+		distance 7234.49
 		period 723.284
 		object
 			sprite planet/ice8
@@ -3498,7 +3498,7 @@ system Alnilam
 			period 16.5247
 	object
 		sprite planet/gas2
-		distance 2758.68
+		distance 11811.97
 		period 1399.52
 		object
 			sprite planet/dust1-b
@@ -3522,8 +3522,8 @@ system Alnitak
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 349.375
-	belt 1907
+	habitable 1190.35
+	belt 7828.11
 	haze _menu/haze-67
 	link Rigel
 	link Mintaka
@@ -3551,28 +3551,28 @@ system Alnitak
 	fleet "Republic Logistics" 6000
 	object
 		sprite star/m0
-		distance 31.1055
+		distance 83.2
 		period 15.4564
 	object
 		sprite star/m4
-		distance 49.3945
+		distance 138.06
 		period 15.4564
 		offset 180
 	object Farpoint
 		sprite planet/forest0-b
-		distance 292.484
+		distance 978.0
 		period 107.045
 	object
 		sprite planet/gas13-b
-		distance 851.724
+		distance 3195.11
 		period 531.94
 	object
 		sprite planet/rock7
-		distance 1223.93
+		distance 4779.59
 		period 916.329
 	object
 		sprite planet/gas1
-		distance 2144.82
+		distance 8922.79
 		period 2125.7
 
 system Alniyat
@@ -3580,8 +3580,8 @@ system Alniyat
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 534.375
-	belt 1760
+	habitable 1905.33
+	belt 7159.33
 	link Pherkad
 	link Graffias
 	link Antares
@@ -3613,16 +3613,16 @@ system Alniyat
 	fleet "Large Militia" 3000
 	object
 		sprite star/k5
-		distance 41.9222
+		distance 115.34
 		period 18.4847
 	object
 		sprite star/m0
-		distance 62.5778
+		distance 178.96
 		period 18.4847
 		offset 180
 	object
 		sprite planet/cloud0-b
-		distance 363.078
+		distance 1242.1
 		period 119.712
 		object Twinstar
 			sprite planet/rock3
@@ -3630,15 +3630,15 @@ system Alniyat
 			period 19.3086
 	object
 		sprite planet/desert7-b
-		distance 718.168
+		distance 2644.18
 		period 333.024
 	object
 		sprite planet/mars-b
-		distance 1176.81
+		distance 4575.51
 		period 698.546
 	object
 		sprite planet/jupiter
-		distance 1943.65
+		distance 7995.82
 		period 1482.73
 		object
 			sprite planet/lava1
@@ -3654,8 +3654,8 @@ system "Alpha Arae"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 945
-	belt 1405
+	habitable 3585.87
+	belt 5572.04
 	link "Delta Sagittarii"
 	link Rastaban
 	link "Kaus Borealis"
@@ -3685,16 +3685,16 @@ system "Alpha Arae"
 	fleet "Large Southern Pirates" 9000
 	object
 		sprite star/g5
-		distance 31.1534
+		distance 83.34
 		period 11.4822
 		offset 180
 	object
 		sprite star/k5
-		distance 60.8466
+		distance 173.53
 		period 11.4822
 	object
 		sprite planet/fog0-b
-		distance 433.097
+		distance 1509.74
 		period 117.279
 		object
 			sprite planet/dust0
@@ -3702,11 +3702,11 @@ system "Alpha Arae"
 			period 14.1602
 	object
 		sprite planet/ocean5
-		distance 788.507
+		distance 2933.01
 		period 288.106
 	object
 		sprite planet/gas8
-		distance 1302.15
+		distance 5120.36
 		period 611.412
 		object
 			sprite planet/dust2-b
@@ -3714,11 +3714,11 @@ system "Alpha Arae"
 			period 17.5306
 	object
 		sprite planet/dust4-b
-		distance 1852.15
+		distance 7577.84
 		period 1037.19
 	object
 		sprite planet/desert4
-		distance 2940.4
+		distance 12682.83
 		period 2074.69
 
 system "Alpha Centauri"
@@ -3726,8 +3726,8 @@ system "Alpha Centauri"
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 320
-	belt 1116
+	habitable 1080.19
+	belt 4313.52
 	haze _menu/haze-67
 	link Sol
 	asteroids "small rock" 1 1.944
@@ -3753,16 +3753,16 @@ system "Alpha Centauri"
 	fleet "Large Republic" 6000
 	object
 		sprite star/k5
-		distance 26.7033
+		distance 70.41
 		period 16.011
 		offset 180
 	object
 		sprite star/m4
-		distance 63.2967
+		distance 181.22
 		period 16.011
 	object Chiron
 		sprite planet/forest1
-		distance 346.547
+		distance 1179.7
 		period 120.975
 		object
 			sprite planet/rock17
@@ -3770,19 +3770,19 @@ system "Alpha Centauri"
 			period 14.7361
 	object
 		sprite planet/desert2
-		distance 749.037
+		distance 2770.56
 		period 384.423
 	object
 		sprite planet/oberon
-		distance 976.197
+		distance 3717.57
 		period 571.953
 	object
 		sprite planet/rock15-b
-		distance 1718.2
+		distance 6970.32
 		period 1335.56
 	object
 		sprite planet/gas13
-		distance 4080.61
+		distance 18282.1
 		period 4888.11
 
 system "Alpha Hydri"
@@ -3790,8 +3790,8 @@ system "Alpha Hydri"
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1400
-	belt 1839
+	habitable 5549.99
+	belt 7517.96
 	haze _menu/haze-133
 	link Ruchbah
 	asteroids "medium rock" 1 7.467
@@ -3816,28 +3816,28 @@ system "Alpha Hydri"
 	fleet "Korath Raid" 40000
 	object
 		sprite star/g0
-		distance 24.6857
+		distance 64.62
 		period 11.9986
 	object
 		sprite star/k5
-		distance 83.3143
+		distance 245.06
 		period 11.9986
 		offset 180
 	object
 		sprite planet/rock5-b
-		distance 287.674
+		distance 960.24
 		period 52.1612
 	object
 		sprite planet/gas12-b
-		distance 846.484
+		distance 3173.3
 		period 263.284
 	object Nimbus
 		sprite planet/ocean1
-		distance 1376.64
+		distance 5447.1
 		period 546.045
 	object
 		sprite planet/gas7
-		distance 2334.93
+		distance 9808.27
 		period 1206.17
 
 system Alphard
@@ -3845,8 +3845,8 @@ system Alphard
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1080.62
-	belt 1101
+	habitable 4161.85
+	belt 4249.15
 	link Algieba
 	link Zosma
 	link Miaplacidus
@@ -3880,32 +3880,32 @@ system Alphard
 	fleet "Human Miners" 2000
 	object
 		sprite star/g5
-		distance 41.5307
+		distance 114.16
 		period 11.8953
 		offset 180
 	object
 		sprite star/k0
-		distance 56.9693
+		distance 161.44
 		period 11.8953
 	object
 		sprite planet/desert1
-		distance 325.709
+		distance 1101.52
 		period 71.5266
 	object
 		sprite planet/dust6
-		distance 627.949
+		distance 2278.44
 		period 191.474
 	object Follower
 		sprite planet/cloud2
-		distance 925.199
+		distance 3502.53
 		period 342.433
 	object
 		sprite planet/dust3
-		distance 1445.56
+		distance 5751.24
 		period 668.769
 	object
 		sprite planet/tethys
-		distance 2496.56
+		distance 10567.86
 		period 1517.87
 
 system Alphecca
@@ -3913,8 +3913,8 @@ system Alphecca
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1400
-	belt 1101
+	habitable 5549.99
+	belt 4249.15
 	link Alioth
 	link Seginus
 	link Boral
@@ -3935,28 +3935,28 @@ system Alphecca
 	fleet "Small Militia" 5000
 	object
 		sprite star/g0
-		distance 27.8857
+		distance 73.83
 		period 14.4057
 		offset 180
 	object
 		sprite star/k5
-		distance 94.1143
+		distance 280.2
 		period 14.4057
 	object
 		sprite planet/lava2-b
-		distance 350.114
+		distance 1193.14
 		period 70.0343
 	object
 		sprite planet/gas17-b
-		distance 693.404
+		distance 2543.24
 		period 195.198
 	object "New Holland"
 		sprite planet/cloud3
-		distance 1209.16
+		distance 4715.52
 		period 449.494
 	object
 		sprite planet/rock17
-		distance 2097.32
+		distance 8702.95
 		period 1026.82
 
 system Alpheratz
@@ -3964,8 +3964,8 @@ system Alpheratz
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1080.62
-	belt 1645
+	habitable 4161.85
+	belt 6640.64
 	haze _menu/haze-133
 	link "Al Dhanab"
 	link Ruchbah
@@ -3996,20 +3996,20 @@ system Alpheratz
 	fleet "Large Core Pirates" 3000
 	object
 		sprite star/g5
-		distance 48.2767
+		distance 134.63
 		period 14.9084
 	object
 		sprite star/k0
-		distance 66.2233
+		distance 190.43
 		period 14.9084
 		offset 180
 	object
 		sprite planet/fog0
-		distance 306.613
+		distance 1030.35
 		period 65.3294
 	object Moonshake
 		sprite planet/forest4
-		distance 858.853
+		distance 3224.81
 		period 306.268
 		object
 			sprite planet/rock14-b
@@ -4017,11 +4017,11 @@ system Alpheratz
 			period 18.5791
 	object
 		sprite planet/dust0
-		distance 1246.89
+		distance 4879.36
 		period 535.755
 	object
 		sprite planet/gas13-b
-		distance 1763.13
+		distance 7173.5
 		period 900.845
 		object
 			sprite planet/oberon
@@ -4033,8 +4033,8 @@ system Altair
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 945
-	belt 1830
+	habitable 3585.87
+	belt 7477.01
 	link Vega
 	link Sol
 	link "Delta Capricorni"
@@ -4060,28 +4060,28 @@ system Altair
 	fleet "Small Syndicate" 9000
 	object
 		sprite star/g5
-		distance 31.4921
+		distance 84.33
 		period 11.6699
 		offset 180
 	object
 		sprite star/k5
-		distance 61.5079
+		distance 175.6
 		period 11.6699
 	object
 		sprite planet/water0
-		distance 242.318
+		distance 794.45
 		period 49.082
 	object
 		sprite planet/desert4
-		distance 468.568
+		distance 1647.23
 		period 131.978
 	object
 		sprite planet/rock13-b
-		distance 698.458
+		distance 2563.81
 		period 240.19
 	object Shiver
 		sprite planet/cloud8
-		distance 1210.95
+		distance 4723.28
 		period 548.318
 		object
 			sprite planet/rock17-b
@@ -4089,7 +4089,7 @@ system Altair
 			period 15
 	object
 		sprite planet/europa
-		distance 2223.95
+		distance 9290.28
 		period 1364.68
 
 system Aludra
@@ -4097,8 +4097,8 @@ system Aludra
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 455.625
-	belt 1511
+	habitable 1596.92
+	belt 6041.58
 	haze _menu/haze-33
 	link Naos
 	asteroids "small rock" 2 3.8394
@@ -4130,23 +4130,23 @@ system Aludra
 		period 10
 	object
 		sprite planet/desert10-b
-		distance 162.5
+		distance 511.22
 		period 38.8183
 	object Midgard
 		sprite planet/forest5-b
-		distance 449.99
+		distance 1575.07
 		period 178.879
 	object
 		sprite planet/luna
-		distance 1180.4
+		distance 4591.02
 		period 759.976
 	object
 		sprite planet/rock1-b
-		distance 1669.4
+		distance 6750.34
 		period 1278.19
 	object
 		sprite planet/neptune-b
-		distance 2759.01
+		distance 11813.55
 		period 2715.73
 		object
 			sprite planet/dust1
@@ -4162,8 +4162,8 @@ system "Ancient Hope"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 455
-	belt 1439
+	habitable 1594.5
+	belt 5722.22
 	haze _menu/haze-67
 	link "Sol Saryd"
 	link "Far Horizon"
@@ -4192,24 +4192,24 @@ system "Ancient Hope"
 	fleet Heliarch 1500
 	object
 		sprite star/m0
-		distance 25.5165
+		distance 67.0
 		period 14.9555
 	object
 		sprite star/m8
-		distance 60.4835
+		distance 172.4
 		period 14.9555
 		offset 180
 	object
 		sprite planet/rock9
-		distance 241.734
+		distance 792.34
 		period 70.479
 	object "Bright Echo"
 		sprite planet/forest4-b
-		distance 596.624
+		distance 2152.79
 		period 273.278
 	object
 		sprite planet/gas12-b
-		distance 1406.78
+		distance 5579.89
 		period 989.453
 		object
 			sprite planet/lava0
@@ -4221,7 +4221,7 @@ system "Ancient Hope"
 			period 20.3852
 	object
 		sprite planet/gas4-b
-		distance 3035.42
+		distance 13140.78
 		period 3136.05
 		object
 			sprite planet/dust4
@@ -4233,8 +4233,8 @@ system Ankaa
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1003
+	habitable 2266.58
+	belt 3831.11
 	haze _menu/haze-133
 	link Markab
 	link Diphda
@@ -4265,23 +4265,23 @@ system Ankaa
 		period 10
 	object
 		sprite planet/rock4-b
-		distance 214.69
+		distance 695.07
 		period 50.3312
 	object Lodestone
 		sprite planet/rock18
-		distance 563.78
+		distance 2021.84
 		period 214.183
 	object
 		sprite planet/dust3
-		distance 997.42
+		distance 3807.44
 		period 504.008
 	object
 		sprite planet/ice0
-		distance 1347.43
+		distance 5318.72
 		period 791.369
 	object
 		sprite planet/rock0-b
-		distance 2059.68
+		distance 8529.17
 		period 1495.61
 
 system Answer
@@ -4289,8 +4289,8 @@ system Answer
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 425.92
-	belt 1636
+	habitable 1482.07
+	belt 6600.22
 	haze _menu/haze-none
 	link "Bright Void"
 	asteroids "medium rock" 2 6.279
@@ -4323,15 +4323,15 @@ system Answer
 		period 10
 	object
 		sprite planet/tethys-b
-		distance 181
+		distance 575.76
 		period 47.1969
 	object "New Finding"
 		sprite planet/ocean7
-		distance 345.84
+		distance 1177.04
 		period 124.655
 	object
 		sprite planet/gas4
-		distance 1076.6
+		distance 4144.65
 		period 684.664
 		object
 			sprite planet/rock7
@@ -4347,7 +4347,7 @@ system Answer
 			period 39.9065
 	object
 		sprite planet/gas11
-		distance 2097.09
+		distance 8701.89
 		period 1861.32
 
 system Antares
@@ -4355,8 +4355,8 @@ system Antares
 	government Pirate
 	attributes "south"
 	arrival 1500
-	habitable 455.625
-	belt 1778
+	habitable 1596.92
+	belt 7240.88
 	haze _menu/haze-67
 	link Alniyat
 	asteroids "small rock" 10 3.8556
@@ -4386,15 +4386,15 @@ system Antares
 		period 10
 	object
 		sprite planet/ice5-b
-		distance 195.59
+		distance 627.16
 		period 51.2597
 	object Bloodsea
 		sprite planet/cloud7
-		distance 440.84
+		distance 1539.65
 		period 173.451
 	object
 		sprite planet/gas11
-		distance 1239.6
+		distance 4847.66
 		period 817.859
 		object
 			sprite planet/dust1-b
@@ -4410,7 +4410,7 @@ system Antares
 			period 42.5381
 	object
 		sprite planet/uranus
-		distance 2778.76
+		distance 11907.88
 		period 2744.94
 
 system Antevorta
@@ -4418,8 +4418,8 @@ system Antevorta
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 320
-	belt 1994
+	habitable 1080.19
+	belt 8226.81
 	haze _menu/haze-red
 	link Ossipago
 	link Cardea
@@ -4449,23 +4449,23 @@ system Antevorta
 		period 10
 	object
 		sprite planet/desert8
-		distance 152.41
+		distance 476.35
 		period 42.0732
 	object
 		sprite planet/io
-		distance 449.3
+		distance 1572.4
 		period 212.956
 	object
 		sprite planet/lava7-b
-		distance 622.34
+		distance 2255.89
 		period 347.158
 	object
 		sprite planet/cloud8
-		distance 1538.34
+		distance 6163.32
 		period 1349.16
 	object
 		sprite planet/gas2-b
-		distance 3887.63
+		distance 17319.54
 		period 5420.16
 		object
 			sprite planet/dust3
@@ -4484,8 +4484,8 @@ system Ap'arak
 	pos -164.62 -781.858
 	government Wanderer
 	arrival 1500
-	habitable 1080
-	belt 1385
+	habitable 4159.2
+	belt 5483.9
 	haze _menu/haze-none
 	link Chirr'ay'akai
 	link Sich'ka'ara
@@ -4513,15 +4513,15 @@ system Ap'arak
 		period 10
 	object
 		sprite planet/gas9-hot
-		distance 262.16
+		distance 866.6
 		period 51.6652
 	object "Varu Tev'kei"
 		sprite planet/desert3
-		distance 804.77
+		distance 3000.21
 		period 277.879
 	object
 		sprite planet/gas11-b
-		distance 1880.77
+		distance 7708.32
 		period 992.777
 		object
 			sprite planet/rock17
@@ -4541,8 +4541,8 @@ system Arcturus
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1422
+	habitable 1080.19
+	belt 5647.08
 	link Mizar
 	link Rutilicus
 	link Holeb
@@ -4574,7 +4574,7 @@ system Arcturus
 		period 10
 	object "New Greenland"
 		sprite planet/ocean1
-		distance 325.36
+		distance 1100.21
 		period 131.229
 		object
 			sprite planet/callisto
@@ -4582,15 +4582,15 @@ system Arcturus
 			period 21.949
 	object
 		sprite planet/rock6
-		distance 744.05
+		distance 2750.1
 		period 453.825
 	object
 		sprite planet/rock17-b
-		distance 998.54
+		distance 3812.19
 		period 705.559
 	object
 		sprite planet/jupiter
-		distance 1514.83
+		distance 6058.62
 		period 1318.35
 		object
 			sprite planet/io
@@ -4598,7 +4598,7 @@ system Arcturus
 			period 12.8784
 	object
 		sprite planet/oberon-b
-		distance 3311.92
+		distance 14482.91
 		period 4261.91
 
 system Arculus
@@ -4606,8 +4606,8 @@ system Arculus
 	government Remnant
 	attributes "ember waste"
 	arrival 1500
-	habitable 625
-	belt 1536
+	habitable 2266.58
+	belt 6152.89
 	haze _menu/haze-red
 	link Edusa
 	link Cinxia
@@ -4636,11 +4636,11 @@ system Arculus
 		period 10
 	object Seraglio
 		sprite planet/rock13-b
-		distance 209.29
+		distance 675.8
 		period 48.4443
 	object Eminonu
 		sprite planet/rock16-b
-		distance 490.5
+		distance 1732.82
 		period 173.811
 		object Babiali
 			sprite planet/desert4-b
@@ -4648,7 +4648,7 @@ system Arculus
 			period 18.3911
 	object Viminal
 		sprite planet/ocean2
-		distance 923.75
+		distance 3496.44
 		period 449.212
 		object Kumkapi
 			sprite planet/io-b
@@ -4656,7 +4656,7 @@ system Arculus
 			period 17.8986
 	object Xerolophos
 		sprite planet/gas0-hot
-		distance 1734.39
+		distance 7043.46
 		period 1155.69
 		object Topkapi
 			sprite planet/tethys-b
@@ -4672,7 +4672,7 @@ system Arculus
 			period 47.6313
 	object
 		sprite planet/browndwarf-t
-		distance 3358
+		distance 14707.92
 		period 4153
 
 system Arneb
@@ -4680,8 +4680,8 @@ system Arneb
 	government Pirate
 	attributes "north"
 	arrival 1500
-	habitable 1715
-	belt 1947
+	habitable 6955.87
+	belt 8011.16
 	haze _menu/haze-none
 	link Hatysa
 	asteroids "large rock" 1 5.3055
@@ -4706,23 +4706,23 @@ system Arneb
 		period 10
 	object
 		sprite planet/venus
-		distance 206
+		distance 664.09
 		period 28.5581
 	object
 		sprite planet/cloud6-b
-		distance 546.25
+		distance 1952.3
 		period 123.315
 	object
 		sprite planet/desert8
-		distance 829.46
+		distance 3102.54
 		period 230.739
 	object Haven
 		sprite planet/forest6
-		distance 1264.82
+		distance 4957.43
 		period 434.481
 	object
 		sprite planet/io
-		distance 4062.31
+		distance 18190.58
 		period 2500.85
 
 system Ascella
@@ -4730,8 +4730,8 @@ system Ascella
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 640
-	belt 1971
+	habitable 2326.97
+	belt 8121.21
 	haze _menu/haze-133
 	link Peacock
 	link "Zeta Aquilae"
@@ -4764,16 +4764,16 @@ system Ascella
 	fleet "Human Miners" 1600
 	object
 		sprite star/k5
-		distance 43.5
+		distance 120.11
 		period 12.8307
 		offset 180
 	object
 		sprite star/k5
-		distance 43.5
+		distance 120.11
 		period 12.8307
 	object Arabia
 		sprite planet/ocean7
-		distance 439.46
+		distance 1534.32
 		period 145.663
 		object
 			sprite planet/rock14
@@ -4781,11 +4781,11 @@ system Ascella
 			period 19.525
 	object
 		sprite planet/miranda-b
-		distance 830.67
+		distance 3107.56
 		period 378.541
 	object
 		sprite planet/gas0
-		distance 1677.03
+		distance 6784.69
 		period 1085.88
 		object
 			sprite planet/dust5-b
@@ -4797,8 +4797,8 @@ system Asikafarnut
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1342
+	habitable 1080.19
+	belt 5294.9
 	link Silikatakfar
 	link Sobarati
 	link Makferuti
@@ -4827,23 +4827,23 @@ system Asikafarnut
 		period 10
 	object "Sestor Ikfar"
 		sprite planet/desert0
-		distance 237.16
+		distance 775.8
 		period 81.6671
 	object
 		sprite planet/titan-b
-		distance 447.52
+		distance 1565.5
 		period 211.692
 	object
 		sprite planet/ice4
-		distance 646.77
+		distance 2354.28
 		period 367.798
 	object
 		sprite planet/desert2
-		distance 884.13
+		distance 3330.34
 		period 587.84
 	object
 		sprite planet/gas7-b
-		distance 2686.82
+		distance 11469.45
 		period 3114.17
 		object
 			sprite planet/dust7
@@ -4863,8 +4863,8 @@ system Aspidiske
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 135
-	belt 1885
+	habitable 416.76
+	belt 7727.63
 	link Avior
 	link Regor
 	link "Epsilon Leonis"
@@ -4889,11 +4889,11 @@ system Aspidiske
 		period 10
 	object
 		sprite planet/cloud2
-		distance 201.36
+		distance 647.6
 		period 98.3678
 	object
 		sprite planet/gas8
-		distance 1004.4
+		distance 3837.05
 		period 1095.86
 		object
 			sprite planet/rock14
@@ -4909,11 +4909,11 @@ system Aspidiske
 			period 49.2651
 	object
 		sprite planet/dust3-b
-		distance 1854.96
+		distance 7590.64
 		period 2750.39
 	object
 		sprite planet/rhea-b
-		distance 2271.8
+		distance 9513.25
 		period 3727.76
 
 system Atria
@@ -4921,8 +4921,8 @@ system Atria
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 214.375
-	belt 1340
+	habitable 693.94
+	belt 5286.12
 	link Han
 	link Lesath
 	link Dschubba
@@ -4956,11 +4956,11 @@ system Atria
 		period 10
 	object Lichen
 		sprite planet/cloud1
-		distance 176.11
+		distance 558.63
 		period 63.8482
 	object
 		sprite planet/gas16-b
-		distance 774.32
+		distance 2874.51
 		period 588.645
 		object
 			sprite planet/dust5-b
@@ -4972,7 +4972,7 @@ system Atria
 			period 26.126
 	object
 		sprite planet/ice6-b
-		distance 1516.96
+		distance 6068.1
 		period 1614.11
 		object
 			sprite planet/rock7
@@ -4980,7 +4980,7 @@ system Atria
 			period 18.9022
 	object
 		sprite planet/europa
-		distance 2505.05
+		distance 10607.92
 		period 3425.29
 
 system Avior
@@ -4988,8 +4988,8 @@ system Avior
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 1215
-	belt 1097
+	habitable 4740.84
+	belt 4232.0
 	link Aspidiske
 	link Naos
 	link Markeb
@@ -5018,20 +5018,20 @@ system Avior
 	fleet "Large Deep Merchants" 4000
 	object
 		sprite star/g0
-		distance 11
+		distance 26.76
 		period 11.3038
 	object
 		sprite star/m4
-		distance 88
+		distance 260.25
 		period 11.3038
 		offset 180
 	object
 		sprite planet/dust5-b
-		distance 257.41
+		distance 849.27
 		period 47.3925
 	object
 		sprite planet/gas1-b
-		distance 705.02
+		distance 2590.54
 		period 214.82
 		object Mani
 			sprite planet/dust3
@@ -5039,15 +5039,15 @@ system Avior
 			period 12.7057
 	object
 		sprite planet/cloud5-b
-		distance 1536.02
+		distance 6152.98
 		period 690.824
 	object
 		sprite planet/oberon
-		distance 1938.66
+		distance 7972.96
 		period 979.545
 	object
 		sprite planet/gas15
-		distance 2389.82
+		distance 10065.55
 		period 1340.66
 		object "Fenrir Station"
 			sprite planet/station3
@@ -5058,8 +5058,8 @@ system Aya'k'k
 	pos -434.245 -616.57
 	government Wanderer
 	arrival 1500
-	habitable 486.68
-	belt 1586
+	habitable 1717.88
+	belt 6376.15
 	haze _menu/haze-67
 	link Pik'ro'iyak
 	asteroids "small rock" 6 1.9152
@@ -5087,7 +5087,7 @@ system Aya'k'k
 		period 10
 	object "Varu K'prai"
 		sprite planet/ice4
-		distance 334.24
+		distance 1133.46
 		period 110.796
 		object
 			sprite planet/callisto
@@ -5095,11 +5095,11 @@ system Aya'k'k
 			period 27.3733
 	object
 		sprite planet/oberon-b
-		distance 748.24
+		distance 2767.29
 		period 371.107
 	object
 		sprite planet/gas13-b
-		distance 1614.25
+		distance 6502.65
 		period 1175.97
 		object
 			sprite planet/rock3
@@ -5111,7 +5111,7 @@ system Aya'k'k
 			period 18.7229
 	object
 		sprite planet/gas11
-		distance 3009.66
+		distance 13016.46
 		period 2993.74
 
 system Beginning
@@ -5119,8 +5119,8 @@ system Beginning
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 425.92
-	belt 1833
+	habitable 1482.07
+	belt 7490.66
 	link Belonging
 	link "Fallen Leaf"
 	link "Good Omen"
@@ -5155,23 +5155,23 @@ system Beginning
 		period 10
 	object
 		sprite planet/desert8-b
-		distance 227
+		distance 739.19
 		period 66.288
 	object
 		sprite planet/rock1
-		distance 440.89
+		distance 1539.84
 		period 179.428
 	object "Glittering Ice"
 		sprite planet/ice4
-		distance 645.05
+		distance 2347.34
 		period 317.531
 	object
 		sprite planet/gas17
-		distance 1759.26
+		distance 7155.98
 		period 1430.18
 	object
 		sprite planet/gas13-b
-		distance 4101.67
+		distance 18387.48
 		period 5091.4
 		object
 			sprite planet/dust1
@@ -5183,8 +5183,8 @@ system Bellatrix
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 670
-	belt 1564
+	habitable 2448.22
+	belt 6277.81
 	link Menkar
 	link Mirfak
 	asteroids "small rock" 6 4.8438
@@ -5211,20 +5211,20 @@ system Bellatrix
 	fleet "Small Core Pirates" 3000
 	object
 		sprite star/k0
-		distance 34.556
+		distance 93.35
 		period 17.3444
 		offset 180
 	object
 		sprite star/m0
-		distance 73.444
+		distance 213.35
 		period 17.3444
 	object
 		sprite planet/ocean1
-		distance 341.784
+		distance 1161.79
 		period 97.6451
 	object Bluestone
 		sprite planet/rock16
-		distance 704.594
+		distance 2588.81
 		period 289.022
 		object
 			sprite planet/io-b
@@ -5232,11 +5232,11 @@ system Bellatrix
 			period 21.047
 	object
 		sprite planet/ganymede-b
-		distance 1468.75
+		distance 5853.96
 		period 869.854
 	object
 		sprite planet/gas5-b
-		distance 2687.64
+		distance 11473.35
 		period 2153.18
 
 system Belonging
@@ -5244,8 +5244,8 @@ system Belonging
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 625
-	belt 1407
+	habitable 2266.58
+	belt 5580.86
 	link "Bright Void"
 	link "Sol Saryd"
 	link Beginning
@@ -5273,15 +5273,15 @@ system Belonging
 		period 10
 	object "Diligent Hand"
 		sprite planet/rock12
-		distance 203.56
+		distance 655.41
 		period 46.4685
 	object "Cool Forest"
 		sprite planet/ocean0
-		distance 634.6
+		distance 2305.21
 		period 255.782
 	object
 		sprite planet/rock19-b
-		distance 1390.96
+		distance 5510.15
 		period 830.026
 		object
 			sprite planet/callisto
@@ -5289,7 +5289,7 @@ system Belonging
 			period 26.5425
 	object
 		sprite planet/gas9-b
-		distance 1993.97
+		distance 8226.67
 		period 1424.62
 		object
 			sprite planet/tethys-b
@@ -5305,8 +5305,8 @@ system Belug
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 486.68
-	belt 1170
+	habitable 1717.88
+	belt 4546.09
 	link Ekuarik
 	link Speloog
 	asteroids "small rock" 1 5.4432
@@ -5340,19 +5340,19 @@ system Belug
 		period 10
 	object
 		sprite planet/mercury
-		distance 126.01
+		distance 386.3
 		period 25.6475
 	object
 		sprite planet/rock11
-		distance 425.62
+		distance 1480.92
 		period 159.21
 	object "Belug's Plunge"
 		sprite planet/ice4
-		distance 807.26
+		distance 3010.52
 		period 415.871
 	object
 		sprite planet/mars
-		distance 1364.62
+		distance 5394.23
 		period 914.02
 		object
 			sprite planet/europa
@@ -5360,7 +5360,7 @@ system Belug
 			period 26.5425
 	object
 		sprite planet/gas7
-		distance 2421.98
+		distance 10216.62
 		period 2161.2
 		object
 			sprite planet/callisto-b
@@ -5376,8 +5376,8 @@ system Belugt
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 486.68
-	belt 1517
+	habitable 1717.88
+	belt 6068.28
 	link Gupta
 	asteroids "small rock" 8 3.3525
 	asteroids "medium rock" 14 2.0025
@@ -5408,11 +5408,11 @@ system Belugt
 		period 10
 	object
 		sprite planet/lava4-b
-		distance 147.04
+		distance 457.89
 		period 32.3289
 	object "Refuge of Belugt"
 		sprite planet/cloud0
-		distance 466.2
+		distance 1638.01
 		period 182.514
 		object
 			sprite planet/miranda
@@ -5420,15 +5420,15 @@ system Belugt
 			period 25.4101
 	object
 		sprite planet/rock8-b
-		distance 1065.2
+		distance 4095.92
 		period 630.355
 	object
 		sprite planet/lava5
-		distance 1246.56
+		distance 4877.93
 		period 798.009
 	object
 		sprite planet/gas9
-		distance 4008.25
+		distance 17920.52
 		period 4601.19
 		object
 			sprite planet/io
@@ -5452,8 +5452,8 @@ system "Beta Lupi"
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 625
-	belt 1261
+	habitable 2266.58
+	belt 4940.78
 	haze _menu/haze-33
 	link Pherkad
 	link "Kappa Centauri"
@@ -5488,7 +5488,7 @@ system "Beta Lupi"
 		period 10
 	object
 		sprite planet/lava5-b
-		distance 362.09
+		distance 1238.36
 		period 110.241
 		object
 			sprite planet/ice8
@@ -5496,15 +5496,15 @@ system "Beta Lupi"
 			period 23.7903
 	object
 		sprite planet/cloud0-b
-		distance 770.93
+		distance 2860.55
 		period 342.486
 	object
 		sprite planet/rock12
-		distance 1053.57
+		distance 4046.27
 		period 547.161
 	object
 		sprite planet/rock17
-		distance 1976.61
+		distance 8146.95
 		period 1406.05
 
 system Betelgeuse
@@ -5512,8 +5512,8 @@ system Betelgeuse
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1080
-	belt 1641
+	habitable 4159.2
+	belt 6622.67
 	haze _menu/haze-67
 	link Mirzam
 	link Alheka
@@ -5548,19 +5548,19 @@ system Betelgeuse
 		period 10
 	object
 		sprite planet/desert2-b
-		distance 179.44
+		distance 570.29
 		period 29.2568
 	object
 		sprite planet/rock0-b
-		distance 535.69
+		distance 1910.52
 		period 150.91
 	object Prime
 		sprite planet/forest2-b
-		distance 1081.98
+		distance 4167.67
 		period 433.189
 	object
 		sprite planet/ocean4
-		distance 1582.62
+		distance 6361.03
 		period 766.325
 		object
 			sprite planet/lava1-b
@@ -5568,7 +5568,7 @@ system Betelgeuse
 			period 21.6509
 	object
 		sprite planet/gas13-b
-		distance 4580.11
+		distance 20798.48
 		period 3772.78
 		object
 			sprite planet/rock17-b
@@ -5588,8 +5588,8 @@ system Bloptab
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 1080
-	belt 1061
+	habitable 4159.2
+	belt 4077.98
 	link Blugtad
 	asteroids "small rock" 1 4.41
 	asteroids "medium rock" 12 3.6
@@ -5622,23 +5622,23 @@ system Bloptab
 		period 10
 	object
 		sprite planet/desert0
-		distance 171.81
+		distance 543.61
 		period 27.4107
 	object "Bloptab's Furnace"
 		sprite planet/desert9
-		distance 367.22
+		distance 1257.78
 		period 85.652
 	object "Delve of Bloptab"
 		sprite planet/desert2
-		distance 777.219
+		distance 2886.45
 		period 263.732
 	object
 		sprite planet/gas0
-		distance 1252.63
+		distance 4904.34
 		period 539.612
 	object
 		sprite planet/gas7
-		distance 4227.99
+		distance 19020.91
 		period 3346.18
 		object
 			sprite planet/callisto
@@ -5650,8 +5650,8 @@ system Blubipad
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 1080
-	belt 1567
+	habitable 4159.2
+	belt 6291.21
 	haze _menu/haze-133
 	link "Sol Arach"
 	link Miblulub
@@ -5684,23 +5684,23 @@ system Blubipad
 		period 10
 	object
 		sprite planet/dust2-b
-		distance 132.44
+		distance 408.07
 		period 18.5514
 	object
 		sprite planet/cloud8-b
-		distance 356.68
+		distance 1217.91
 		period 81.991
 	object "Blubipad's Workshop"
 		sprite planet/forest3
-		distance 1004.12
+		distance 3835.86
 		period 387.281
 	object
 		sprite planet/cloud2
-		distance 1286.96
+		distance 5054.0
 		period 561.947
 	object
 		sprite planet/rock3
-		distance 3003.77
+		distance 12988.05
 		period 2003.77
 
 system Blugtad
@@ -5708,8 +5708,8 @@ system Blugtad
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 625
-	belt 1841
+	habitable 2266.58
+	belt 7527.07
 	haze _menu/haze-133
 	link Gupta
 	link Eblumab
@@ -5746,11 +5746,11 @@ system Blugtad
 		period 10
 	object
 		sprite planet/ice3
-		distance 249.64
+		distance 821.0
 		period 63.109
 	object "Bank of Blugtad"
 		sprite planet/earth
-		distance 629.067
+		distance 2282.94
 		period 252.444
 		object
 			sprite planet/desert4
@@ -5758,7 +5758,7 @@ system Blugtad
 			period 17.141
 	object
 		sprite planet/gas1-b
-		distance 2037.36
+		distance 8426.29
 		period 1471.37
 		object
 			sprite planet/dust3
@@ -5782,8 +5782,8 @@ system Boral
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 214.375
-	belt 1867
+	habitable 693.94
+	belt 7645.51
 	link Alphecca
 	asteroids "small rock" 7 2.4752
 	asteroids "medium rock" 126 4.42
@@ -5812,7 +5812,7 @@ system Boral
 		period 10
 	object
 		sprite planet/cloud3-b
-		distance 305.39
+		distance 1025.81
 		period 145.799
 		object
 			sprite planet/oberon
@@ -5820,15 +5820,15 @@ system Boral
 			period 21.6824
 	object
 		sprite planet/rock6
-		distance 734.39
+		distance 2710.52
 		period 543.705
 	object
 		sprite planet/rock7-b
-		distance 1160.2
+		distance 4503.79
 		period 1079.62
 	object
 		sprite planet/gas3
-		distance 2420.16
+		distance 10208.07
 		period 3252.66
 		object
 			sprite planet/dust7
@@ -5847,8 +5847,8 @@ system "Bore Fah"
 	pos 71.7761 -592.536
 	government Hai
 	arrival 1500
-	habitable 625
-	belt 1823
+	habitable 2266.58
+	belt 7445.18
 	link "Wah Ki"
 	link "Bote Asu"
 	asteroids "small rock" 29 3.0912
@@ -5880,7 +5880,7 @@ system "Bore Fah"
 		period 10
 	object
 		sprite planet/ice3
-		distance 347.69
+		distance 1184.01
 		period 103.731
 		object
 			sprite planet/callisto-b
@@ -5888,11 +5888,11 @@ system "Bore Fah"
 			period 17.5682
 	object Snowfeather
 		sprite planet/ice2
-		distance 678.69
+		distance 2483.46
 		period 282.896
 	object
 		sprite planet/gas13-b
-		distance 1704.93
+		distance 6910.43
 		period 1126.37
 		object
 			sprite planet/lava0-b
@@ -5907,8 +5907,8 @@ system "Bote Asu"
 	pos 8.87418 -572.768
 	government Hai
 	arrival 1500
-	habitable 2859.44
-	belt 1613
+	habitable 12294.03
+	belt 6497.04
 	link "Wah Ki"
 	link "Ula Mon"
 	link "Ya Hai"
@@ -5938,20 +5938,20 @@ system "Bote Asu"
 	fleet "Hai Surveillance" 3000
 	object
 		sprite star/f0
-		distance 17.3605
+		distance 44.0
 		period 7.70584
 	object
 		sprite star/k0-old
-		distance 84.6395
+		distance 249.35
 		period 7.70584
 		offset 180
 	object
 		sprite planet/rock1
-		distance 242.889
+		distance 796.52
 		period 28.316
 	object
 		sprite planet/rock16
-		distance 634.139
+		distance 2303.35
 		period 119.453
 		object
 			sprite planet/ice7
@@ -5959,11 +5959,11 @@ system "Bote Asu"
 			period 31.0553
 	object
 		sprite planet/gas11
-		distance 1111.15
+		distance 4292.7
 		period 277.063
 	object
 		sprite planet/neptune
-		distance 2561.56
+		distance 10874.99
 		period 969.787
 		object
 			sprite planet/rock7-b
@@ -5979,7 +5979,7 @@ system "Bote Asu"
 			period 41.514
 	object
 		sprite planet/gas12-b
-		distance 4312.6
+		distance 19446.47
 		period 2118.5
 		object
 			sprite planet/rhea-b
@@ -5999,8 +5999,8 @@ system "Bright Void"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 2795
-	belt 1385
+	habitable 11985.5
+	belt 5483.9
 	haze _menu/haze-67
 	link "Steep Roof"
 	link "Silver Bell"
@@ -6032,16 +6032,16 @@ system "Bright Void"
 	fleet Heliarch 500
 	object
 		sprite star/f5
-		distance 54.8694
+		distance 154.92
 		period 12.8027
 	object
 		sprite star/g0
-		distance 87.1306
+		distance 257.42
 		period 12.8027
 		offset 180
 	object
 		sprite planet/ice3
-		distance 398.421
+		distance 1376.54
 		period 60.1702
 		object
 			sprite planet/lava0
@@ -6049,15 +6049,15 @@ system "Bright Void"
 			period 22.7102
 	object
 		sprite planet/ice7
-		distance 771.831
+		distance 2864.26
 		period 162.238
 	object
 		sprite planet/europa
-		distance 1238.39
+		distance 4842.4
 		period 329.728
 	object
 		sprite planet/gas17
-		distance 1637.68
+		distance 6607.76
 		period 501.433
 		object
 			sprite planet/callisto
@@ -6065,7 +6065,7 @@ system "Bright Void"
 			period 13.1879
 	object
 		sprite planet/gas7-b
-		distance 2577.77
+		distance 10951.73
 		period 990.229
 		object
 			sprite planet/ice0-b
@@ -6081,8 +6081,8 @@ system "Broken Bowl"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1080
-	belt 1648
+	habitable 4159.2
+	belt 6654.11
 	haze _menu/haze-67
 	link "Dark Hills"
 	link Hunter
@@ -6114,23 +6114,23 @@ system "Broken Bowl"
 		period 10
 	object
 		sprite planet/mars
-		distance 202.41
+		distance 651.33
 		period 35.0506
 	object
 		sprite planet/ice5
-		distance 551.65
+		distance 1973.69
 		period 157.704
 	object "Warm Wind"
 		sprite planet/forest5
-		distance 827.41
+		distance 3094.03
 		period 289.687
 	object
 		sprite planet/lava1
-		distance 1185.02
+		distance 4611.0
 		period 496.52
 	object
 		sprite planet/gas6-b
-		distance 2068.02
+		distance 8567.64
 		period 1144.67
 		object
 			sprite planet/dust4
@@ -6142,8 +6142,8 @@ system Caeculus
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 320
-	belt 1797
+	habitable 1080.19
+	belt 7327.07
 	haze _menu/haze-red
 	link Stercutus
 	asteroids "small rock" 3 0.5704
@@ -6173,15 +6173,15 @@ system Caeculus
 		period 10
 	object
 		sprite planet/dust6-b
-		distance 127.09
+		distance 389.95
 		period 32.037
 	object
 		sprite planet/desert9
-		distance 341.05
+		distance 1159.03
 		period 140.835
 	object
 		sprite planet/gas5-b
-		distance 993.81
+		distance 3792.14
 		period 700.551
 		object
 			sprite planet/rock14-b
@@ -6193,11 +6193,11 @@ system Caeculus
 			period 21.7746
 	object
 		sprite planet/rock3
-		distance 1683.81
+		distance 6815.22
 		period 1544.99
 	object
 		sprite planet/jupiter-b
-		distance 2187.82
+		distance 9122.29
 		period 2288.24
 		object
 			sprite planet/rhea-b
@@ -6213,8 +6213,8 @@ system Canopus
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 214.375
-	belt 1530
+	habitable 693.94
+	belt 6126.16
 	haze _menu/haze-67
 	link Phurad
 	link Mirzam
@@ -6241,19 +6241,19 @@ system Canopus
 		period 10
 	object Splashdown
 		sprite planet/ice7
-		distance 166.5
+		distance 525.11
 		period 58.6941
 	object
 		sprite planet/ocean0
-		distance 399.59
+		distance 1381.01
 		period 218.22
 	object
 		sprite planet/io-b
-		distance 719.95
+		distance 2651.46
 		period 527.748
 	object
 		sprite planet/dust0-b
-		distance 1975.56
+		distance 8142.13
 		period 2398.88
 
 system Capella
@@ -6261,8 +6261,8 @@ system Capella
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 455.625
-	belt 1722
+	habitable 1596.92
+	belt 6987.48
 	haze _menu/haze-67
 	link Procyon
 	link Aldebaran
@@ -6297,23 +6297,23 @@ system Capella
 		period 10
 	object
 		sprite planet/dust5-b
-		distance 212.75
+		distance 688.14
 		period 58.1515
 	object Hermes
 		sprite planet/ocean5
-		distance 532.24
+		distance 1896.9
 		period 230.1
 	object
 		sprite planet/rock5-b
-		distance 804.45
+		distance 2998.89
 		period 427.568
 	object
 		sprite planet/rhea-b
-		distance 1167.09
+		distance 4533.52
 		period 747.158
 	object
 		sprite planet/gas11-b
-		distance 1985.85
+		distance 8189.37
 		period 1658.35
 		object
 			sprite planet/io
@@ -6333,8 +6333,8 @@ system Caph
 	government Syndicate
 	attributes "near earth"
 	arrival 1500
-	habitable 670
-	belt 1173
+	habitable 2448.22
+	belt 4559.04
 	link Sol
 	link Diphda
 	link Eteron
@@ -6366,15 +6366,15 @@ system Caph
 		period 10
 	object
 		sprite planet/desert0
-		distance 160.16
+		distance 503.12
 		period 24.6706
 	object
 		sprite planet/lava3
-		distance 479.25
+		distance 1688.86
 		period 127.7
 	object Reunion
 		sprite planet/forest2
-		distance 885.61
+		distance 3336.53
 		period 320.783
 		object
 			sprite planet/mercury-b
@@ -6382,7 +6382,7 @@ system Caph
 			period 19.3731
 	object
 		sprite planet/gas6
-		distance 1666.37
+		distance 6736.71
 		period 827.952
 		object "Kraken Station"
 			sprite planet/station10
@@ -6390,7 +6390,7 @@ system Caph
 			period 10.5056
 	object
 		sprite planet/gas10
-		distance 2434.98
+		distance 10277.75
 		period 1462.48
 
 system Cardax
@@ -6398,8 +6398,8 @@ system Cardax
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1705
-	belt 1228
+	habitable 6910.75
+	belt 4797.26
 	link Moktar
 	link Volax
 	link Sumar
@@ -6429,28 +6429,28 @@ system Cardax
 	fleet "Large Republic" 5000
 	object
 		sprite star/g0
-		distance 45.4545
+		distance 126.03
 		period 13.3761
 		offset 180
 	object
 		sprite star/g5
-		distance 78.5455
+		distance 229.69
 		period 13.3761
 	object
 		sprite planet/rock8-b
-		distance 315.795
+		distance 1064.51
 		period 54.3634
 	object
 		sprite planet/io
-		distance 667.205
+		distance 2436.9
 		period 166.95
 	object
 		sprite planet/ice8
-		distance 1271.3
+		distance 4985.67
 		period 439.104
 	object
 		sprite planet/gas1
-		distance 2131.94
+		distance 8863.12
 		period 953.584
 		object
 			sprite planet/rock0
@@ -6462,8 +6462,8 @@ system Cardea
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 851.84
-	belt 1725
+	habitable 3195.59
+	belt 7001.03
 	haze _menu/haze-red
 	link Nenia
 	link Antevorta
@@ -6489,28 +6489,28 @@ system Cardea
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/k5-old
-		distance 47.5
+		distance 132.26
 		period 12.6901
 		offset 180
 	object
 		sprite star/k5
-		distance 47.5
+		distance 132.26
 		period 12.6901
 	object
 		sprite planet/desert7-b
-		distance 260.94
+		distance 862.14
 		period 57.7686
 	object
 		sprite planet/rock2-b
-		distance 629.55
+		distance 2284.88
 		period 216.484
 	object
 		sprite planet/miranda-b
-		distance 969.79
+		distance 3690.48
 		period 413.902
 	object
 		sprite planet/neptune-b
-		distance 1490.63
+		distance 5951.05
 		period 788.743
 		object
 			sprite planet/callisto
@@ -6518,11 +6518,11 @@ system Cardea
 			period 17.0401
 	object "Ember Threshold"
 		sprite planet/wormhole-red
-		distance 2500
+		distance 10584.09
 		period 1713.14
 	object "Ember Wormhole"
 		sprite planet/wormhole-red
-		distance 3252.92
+		distance 14195.37
 		period 2542.68
 
 system Castor
@@ -6530,8 +6530,8 @@ system Castor
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1715
-	belt 1675
+	habitable 6955.87
+	belt 6775.55
 	haze _menu/haze-67
 	link Pollux
 	link Talita
@@ -6563,16 +6563,16 @@ system Castor
 	fleet "Republic Logistics" 2000
 	object
 		sprite star/g5
-		distance 52.9147
+		distance 148.88
 		period 17.1076
 	object
 		sprite star/k0
-		distance 72.5853
+		distance 210.62
 		period 17.1076
 		offset 180
 	object
 		sprite planet/ice5-b
-		distance 455.085
+		distance 1594.83
 		period 118.13
 		object
 			sprite planet/dust3
@@ -6580,15 +6580,15 @@ system Castor
 			period 14.4508
 	object
 		sprite planet/rock0
-		distance 758.695
+		distance 2810.22
 		period 254.287
 	object Geminus
 		sprite planet/rock18
-		distance 994.305
+		distance 3794.24
 		period 381.507
 	object
 		sprite planet/uranus
-		distance 1759.55
+		distance 7157.29
 		period 898.097
 		object
 			sprite planet/desert4-b
@@ -6596,7 +6596,7 @@ system Castor
 			period 11.4109
 	object
 		sprite planet/gas8-b
-		distance 5273.71
+		distance 24347.35
 		period 4660.11
 		object
 			sprite planet/lava2-b
@@ -6616,8 +6616,8 @@ system Cebalrai
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 625
-	belt 1955
+	habitable 2266.58
+	belt 8047.83
 	link Rutilicus
 	link "Kaus Borealis"
 	link Rasalhague
@@ -6650,15 +6650,15 @@ system Cebalrai
 		period 10
 	object
 		sprite planet/miranda-b
-		distance 198.36
+		distance 636.96
 		period 44.6993
 	object
 		sprite planet/ocean6-b
-		distance 492.57
+		distance 1740.93
 		period 174.913
 	object Tundra
 		sprite planet/ice1
-		distance 1070.13
+		distance 4116.99
 		period 560.112
 		object
 			sprite planet/desert4-b
@@ -6666,11 +6666,11 @@ system Cebalrai
 			period 13.3875
 	object
 		sprite planet/desert2
-		distance 1673.13
+		distance 6767.13
 		period 1095
 	object
 		sprite planet/tethys-b
-		distance 2206.54
+		distance 9209.29
 		period 1658.39
 
 system Celeborim
@@ -6678,8 +6678,8 @@ system Celeborim
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1296
+	habitable 1080.19
+	belt 5093.48
 	link Asikafarnut
 	asteroids "small rock" 4 3.9
 	asteroids "medium rock" 5 4.4616
@@ -6706,23 +6706,23 @@ system Celeborim
 		period 10
 	object "Firka Tesk"
 		sprite planet/lava3
-		distance 194.84
+		distance 624.5
 		period 60.8138
 	object
 		sprite planet/ocean9
-		distance 541.25
+		distance 1932.51
 		period 281.567
 	object
 		sprite planet/lava7-b
-		distance 901.09
+		distance 3401.34
 		period 604.835
 	object
 		sprite planet/dust2
-		distance 1764.34
+		distance 7178.98
 		period 1657.14
 	object
 		sprite planet/gas5-b
-		distance 3744.58
+		distance 16609.69
 		period 5123.77
 		object
 			sprite planet/dust4
@@ -6738,8 +6738,8 @@ system Chikatip
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 425.92
-	belt 1929
+	habitable 1482.07
+	belt 7928.73
 	link Furmeliki
 	link Seketra
 	asteroids "small rock" 112 4.4965
@@ -6767,11 +6767,11 @@ system Chikatip
 		period 10
 	object
 		sprite planet/ganymede-b
-		distance 124.36
+		distance 380.74
 		period 26.8792
 	object
 		sprite planet/uranus-b
-		distance 690.755
+		distance 2532.47
 		period 351.87
 		object "Selefkar Refinery"
 			sprite planet/station3k
@@ -6779,15 +6779,15 @@ system Chikatip
 			period 19.97
 	object
 		sprite planet/dust3
-		distance 1174.6
+		distance 4565.96
 		period 780.247
 	object
 		sprite planet/cloud5-b
-		distance 1387.21
+		distance 5493.63
 		period 1001.41
 	object
 		sprite planet/gas14-b
-		distance 3728.22
+		distance 16528.71
 		period 4412.13
 
 system Chimitarp
@@ -6795,8 +6795,8 @@ system Chimitarp
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 912.6
-	belt 1932
+	habitable 3449.61
+	belt 7942.47
 	haze _menu/haze-133
 	link Mekislepti
 	link Sepetrosk
@@ -6824,24 +6824,24 @@ system Chimitarp
 	fleet "Kor Mereti Miners" 2000
 	object
 		sprite star/k0
-		distance 53.205
+		distance 149.78
 		period 16.1167
 		offset 180
 	object
 		sprite star/k5
-		distance 60.795
+		distance 173.37
 		period 16.1167
 	object
 		sprite planet/cloud8-b
-		distance 275.405
+		distance 915.09
 		period 60.517
 	object
 		sprite planet/desert9-b
-		distance 585.045
+		distance 2106.53
 		period 187.372
 	object "Korbatri Eska"
 		sprite planet/earth
-		distance 886.135
+		distance 3338.72
 		period 349.277
 		object
 			sprite planet/desert4
@@ -6849,7 +6849,7 @@ system Chimitarp
 			period 15.1748
 	object
 		sprite planet/gas3
-		distance 1601.13
+		distance 6443.86
 		period 848.322
 		object "Rekat Moraski"
 			sprite planet/station1k
@@ -6857,7 +6857,7 @@ system Chimitarp
 			period 17.1217
 	object
 		sprite planet/gas16
-		distance 2391.9
+		distance 10075.32
 		period 1548.93
 		object
 			sprite planet/europa
@@ -6868,8 +6868,8 @@ system Chirr'ay'akai
 	pos -102.761 -749.614
 	government Wanderer
 	arrival 1500
-	habitable 486.68
-	belt 1425
+	habitable 1717.88
+	belt 5660.33
 	haze _menu/haze-33
 	link Prakacha'a
 	link Ap'arak
@@ -6895,19 +6895,19 @@ system Chirr'ay'akai
 		period 10
 	object
 		sprite planet/lava5-b
-		distance 225.49
+		distance 733.76
 		period 61.3945
 	object "Kort Vek'kri"
 		sprite planet/rock1
-		distance 624.98
+		distance 2266.5
 		period 283.294
 	object
 		sprite planet/gas1
-		distance 1283.62
+		distance 5039.42
 		period 833.86
 	object
 		sprite planet/jupiter
-		distance 2657.98
+		distance 11332.28
 		period 2484.65
 		object
 			sprite planet/desert4-b
@@ -6919,8 +6919,8 @@ system Chornifath
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1434
+	habitable 1717.88
+	belt 5700.1
 	haze _menu/haze-133
 	link Dokdobaru
 	asteroids "small rock" 2 6.9776
@@ -6945,7 +6945,7 @@ system Chornifath
 		period 10
 	object
 		sprite planet/rock4
-		distance 320.84
+		distance 1083.33
 		period 104.201
 		object
 			sprite planet/rock17
@@ -6953,7 +6953,7 @@ system Chornifath
 			period 19.8241
 	object "Eskar Kortuka"
 		sprite planet/ocean7
-		distance 804.591
+		distance 2999.47
 		period 413.81
 		object
 			sprite planet/station1kd
@@ -6961,11 +6961,11 @@ system Chornifath
 			period 20.2555
 	object
 		sprite planet/ice3-b
-		distance 1233.75
+		distance 4822.24
 		period 785.741
 	object
 		sprite planet/gas12-b
-		distance 1945.96
+		distance 8006.4
 		period 1556.47
 		object
 			sprite planet/ice7-b
@@ -6980,8 +6980,8 @@ system Chy'chra
 	pos 85.5308 -829.667
 	government Wanderer
 	arrival 1500
-	habitable 625
-	belt 1120
+	habitable 2266.58
+	belt 4330.71
 	haze _menu/haze-33
 	link Prakacha'a
 	link Ik'kara'ka
@@ -7010,19 +7010,19 @@ system Chy'chra
 		period 10
 	object
 		sprite planet/lava3-b
-		distance 156.64
+		distance 490.94
 		period 31.3671
 	object
 		sprite planet/dust6-b
-		distance 399.89
+		distance 1382.16
 		period 127.947
 	object "Varu K'est"
 		sprite planet/dust2
-		distance 681.1
+		distance 2493.24
 		period 284.404
 	object
 		sprite planet/gas10-b
-		distance 1515.91
+		distance 6063.43
 		period 944.344
 		object
 			sprite planet/ice7-b
@@ -7046,8 +7046,8 @@ system Cinxia
 	government Remnant
 	attributes "ember waste"
 	arrival 1500
-	habitable 425.92
-	belt 1713
+	habitable 1482.07
+	belt 6946.85
 	haze _menu/haze-red
 	link Arculus
 	link Perfica
@@ -7075,7 +7075,7 @@ system Cinxia
 		period 10
 	object Caelian
 		sprite planet/cloud3
-		distance 279.25
+		distance 929.22
 		period 90.4452
 		object Tibernia
 			sprite planet/dust1
@@ -7083,15 +7083,15 @@ system Cinxia
 			period 17.2478
 	object Janiculum
 		sprite planet/ice6
-		distance 745.09
+		distance 2754.37
 		period 394.193
 	object Vatican
 		sprite planet/lava0
-		distance 922.93
+		distance 3492.99
 		period 543.437
 	object Palatine
 		sprite planet/gas9-b
-		distance 2326.18
+		distance 9767.33
 		period 2174.51
 		object Pincian
 			sprite planet/rock20
@@ -7103,8 +7103,8 @@ system Coluber
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 659.2
-	belt 1590
+	habitable 2404.5
+	belt 6394.04
 	haze _menu/haze-red
 	link Parca
 	link Levana
@@ -7130,24 +7130,24 @@ system Coluber
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/k5-old
-		distance 40.6966
+		distance 111.65
 		period 19.2131
 		offset 180
 	object
 		sprite star/m4
-		distance 74.3034
+		distance 216.1
 		period 19.2131
 	object
 		sprite planet/ice4-b
-		distance 248.663
+		distance 817.45
 		period 61.0899
 	object
 		sprite planet/desert7
-		distance 439.103
+		distance 1532.94
 		period 143.351
 	object
 		sprite planet/fog0-b
-		distance 814.743
+		distance 3041.5
 		period 362.312
 		object
 			sprite planet/dust4-b
@@ -7155,19 +7155,19 @@ system Coluber
 			period 21.179
 	object
 		sprite planet/rock10
-		distance 1208.18
+		distance 4711.27
 		period 654.26
 	object "Ember Reaches"
 		sprite planet/wormhole-red
-		distance 2354.54
+		distance 9900.11
 		period 1779.96
 
 system Companion
 	pos -1032.59 709.051
 	government Coalition
 	arrival 1500
-	habitable 425.92
-	belt 1786
+	habitable 1482.07
+	belt 7277.15
 	haze _menu/haze-133
 	link "Sol Saryd"
 	link "Far Horizon"
@@ -7201,19 +7201,19 @@ system Companion
 		period 10
 	object
 		sprite planet/desert1
-		distance 211.56
+		distance 683.89
 		period 59.6412
 	object "Far Garden"
 		sprite planet/forest4-b
-		distance 497.8
+		distance 1761.41
 		period 215.267
 	object
 		sprite planet/desert6-b
-		distance 736.41
+		distance 2718.79
 		period 387.325
 	object
 		sprite planet/gas13-b
-		distance 2044.05
+		distance 8457.11
 		period 1791.16
 		object
 			sprite planet/dust3-b
@@ -7225,8 +7225,8 @@ system Convector
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 4131.68
-	belt 1961
+	habitable 18537.76
+	belt 8075.34
 	haze _menu/haze-red
 	link Antevorta
 	asteroids "small rock" 7 1.805
@@ -7249,32 +7249,32 @@ system Convector
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/giant
-		distance 13.0749
+		distance 32.3
 		period 7.27748
 	object
 		sprite star/k0-old
-		distance 97.9251
+		distance 292.7
 		period 7.27748
 		offset 180
 	object
 		sprite planet/cloud1
-		distance 311.885
+		distance 1049.95
 		period 34.2759
 	object
 		sprite planet/desert9-b
-		distance 749.895
+		distance 2774.08
 		period 127.79
 	object
 		sprite planet/rock6
-		distance 941.385
+		distance 3570.64
 		period 179.741
 	object
 		sprite planet/rock5-b
-		distance 1178.23
+		distance 4581.64
 		period 251.674
 	object
 		sprite planet/gas11-b
-		distance 1600.52
+		distance 6441.13
 		period 398.461
 		object
 			sprite planet/rock3-b
@@ -7282,7 +7282,7 @@ system Convector
 			period 14.6327
 	object "Ember Reaches"
 		sprite planet/wormhole-red
-		distance 6592.96
+		distance 31250.09
 		period 3331.32
 
 system "Cor Caroli"
@@ -7290,8 +7290,8 @@ system "Cor Caroli"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1474
+	habitable 4159.2
+	belt 5877.24
 	link Vindemiatrix
 	link Gacrux
 	link Algorel
@@ -7326,15 +7326,15 @@ system "Cor Caroli"
 		period 10
 	object
 		sprite planet/rock0
-		distance 121.21
+		distance 370.14
 		period 16.2426
 	object
 		sprite planet/water1-b
-		distance 422.7
+		distance 1469.68
 		period 105.778
 	object Heartland
 		sprite planet/ocean1
-		distance 977.7
+		distance 3723.93
 		period 372.097
 		object
 			sprite planet/io
@@ -7342,15 +7342,15 @@ system "Cor Caroli"
 			period 19.1728
 	object
 		sprite planet/tethys
-		distance 2019.86
+		distance 8345.72
 		period 1104.92
 
 system "Da Ent"
 	pos -6.22391 -462.536
 	government Hai
 	arrival 1500
-	habitable 233.28
-	belt 1161
+	habitable 761.8
+	belt 4507.24
 	link "Ya Hai"
 	asteroids "small rock" 31 1.3005
 	asteroids "medium rock" 21 3.213
@@ -7379,7 +7379,7 @@ system "Da Ent"
 		period 10
 	object Newhome
 		sprite planet/ice4
-		distance 276.21
+		distance 918.05
 		period 120.221
 		object
 			sprite planet/dust1
@@ -7387,15 +7387,15 @@ system "Da Ent"
 			period 23.3253
 	object
 		sprite planet/desert10-b
-		distance 622.02
+		distance 2254.6
 		period 406.282
 	object
 		sprite planet/lava4
-		distance 1094.46
+		distance 4221.11
 		period 948.246
 	object
 		sprite planet/gas12
-		distance 1915.5
+		distance 7866.97
 		period 2195.56
 		object
 			sprite planet/callisto
@@ -7410,8 +7410,8 @@ system "Da Lest"
 	pos -23.2239 -413.536
 	government Hai
 	arrival 1500
-	habitable 320
-	belt 1108
+	habitable 1080.19
+	belt 4279.18
 	link "Lom Tahr"
 	asteroids "small rock" 5 3.69
 	asteroids "medium rock" 7 4.17
@@ -7442,19 +7442,19 @@ system "Da Lest"
 		period 10
 	object
 		sprite planet/ice2
-		distance 192.61
+		distance 616.62
 		period 59.7728
 	object Frostmark
 		sprite planet/forest3-b
-		distance 416.7
+		distance 1446.6
 		period 190.204
 	object
 		sprite planet/desert2-b
-		distance 676.46
+		distance 2474.41
 		period 393.413
 	object
 		sprite planet/gas9
-		distance 1903.15
+		distance 7810.52
 		period 1856.5
 		object
 			sprite planet/rock3
@@ -7466,8 +7466,8 @@ system Dabih
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 670
-	belt 1088
+	habitable 2448.22
+	belt 4193.44
 	haze _menu/haze-133
 	link Tarazed
 	link Eltanin
@@ -7494,24 +7494,24 @@ system Dabih
 	fleet "Large Southern Pirates" 10000
 	object
 		sprite star/k0
-		distance 30.7164
+		distance 82.06
 		period 14.5355
 		offset 180
 	object
 		sprite star/m0
-		distance 65.2836
+		distance 187.47
 		period 14.5355
 	object
 		sprite planet/cloud3-b
-		distance 288.034
+		distance 961.57
 		period 75.5418
 	object "New Britain"
 		sprite planet/forest6-b
-		distance 742.074
+		distance 2742.0
 		period 312.387
 	object
 		sprite planet/gas2
-		distance 1761.48
+		distance 7166.03
 		period 1142.46
 		object
 			sprite planet/ice0
@@ -7527,8 +7527,8 @@ system Danoa
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 135
-	belt 1689
+	habitable 416.76
+	belt 6838.61
 	haze _menu/haze-67
 	link Sumar
 	link Hassaleh
@@ -7561,11 +7561,11 @@ system Danoa
 		period 10
 	object
 		sprite planet/desert7-b
-		distance 168.64
+		distance 532.56
 		period 75.3935
 	object
 		sprite planet/fog0-b
-		distance 693.93
+		distance 2545.38
 		period 629.313
 		object
 			sprite planet/mercury
@@ -7573,7 +7573,7 @@ system Danoa
 			period 15.1961
 	object
 		sprite planet/gas6
-		distance 2069.42
+		distance 8574.1
 		period 3240.9
 		object
 			sprite planet/lava1-b
@@ -7597,8 +7597,8 @@ system "Dark Hills"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1080
-	belt 1367
+	habitable 4159.2
+	belt 5404.7
 	link Beginning
 	link Remembrance
 	link "Broken Bowl"
@@ -7633,7 +7633,7 @@ system "Dark Hills"
 		period 10
 	object
 		sprite planet/gas7
-		distance 384.56
+		distance 1323.65
 		period 91.7898
 		object
 			sprite planet/io
@@ -7641,7 +7641,7 @@ system "Dark Hills"
 			period 12.0062
 	object
 		sprite planet/jupiter-b
-		distance 1131.12
+		distance 4378.51
 		period 463.032
 		object
 			sprite planet/lava0-b
@@ -7653,11 +7653,11 @@ system "Dark Hills"
 			period 23.0024
 	object
 		sprite planet/gas11-b
-		distance 1788.61
+		distance 7288.99
 		period 920.707
 	object
 		sprite planet/desert4-b
-		distance 2367.9
+		distance 9962.73
 		period 1402.47
 
 system Debrugt
@@ -7665,8 +7665,8 @@ system Debrugt
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 640
-	belt 1224
+	habitable 2326.97
+	belt 4779.89
 	link Torbab
 	link Flugbu
 	link Mebla
@@ -7691,24 +7691,24 @@ system Debrugt
 	fleet Heliarch 300
 	object
 		sprite star/m0
-		distance 48.5
+		distance 135.32
 		period 15.1052
 		offset 180
 	object
 		sprite star/m0
-		distance 48.5
+		distance 135.32
 		period 15.1052
 	object
 		sprite planet/cloud8
-		distance 236.46
+		distance 773.27
 		period 57.4919
 	object "Hammer of Debrugt"
 		sprite planet/cloud5
-		distance 689.71
+		distance 2528.22
 		period 286.398
 	object
 		sprite planet/gas4-b
-		distance 1481.72
+		distance 5911.49
 		period 901.819
 		object
 			sprite planet/dust5
@@ -7720,7 +7720,7 @@ system Debrugt
 			period 25.1015
 	object
 		sprite planet/gas1
-		distance 2443.48
+		distance 10317.75
 		period 1909.78
 		object
 			sprite planet/tethys
@@ -7737,7 +7737,7 @@ system Delia
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 486.68
+	habitable 1717.88
 	link Dixere
 	link Giribea
 	asteroids "large metal" 10 9
@@ -7768,32 +7768,32 @@ system Delia
 		period 10
 	object
 		sprite planet/dyson1
-		distance 160.21
+		distance 503.29
 		period 36.7682
 		offset 217.144
 	object
 		sprite planet/dyson2
-		distance 160.21
+		distance 503.29
 		period 36.7682
 		offset 181.163
 	object
 		sprite planet/dyson3
-		distance 160.21
+		distance 503.29
 		period 36.7682
 		offset 294.239
 	object
 		sprite planet/cloud3
-		distance 589.01
+		distance 2122.36
 		period 259.192
 		offset 20.1203
 	object
 		sprite planet/desert9-b
-		distance 748.5
+		distance 2768.36
 		period 371.301
 		offset 34.9671
 	object
 		sprite planet/gas11
-		distance 2258.66
+		distance 9451.97
 		period 1946.32
 		offset 23.3162
 		object
@@ -7810,7 +7810,7 @@ system Delia
 			period 38.9968
 	object
 		sprite planet/browndwarf-y
-		distance 4586
+		distance 20828.36
 		period 8024
 
 system "Delta Capricorni"
@@ -7818,8 +7818,8 @@ system "Delta Capricorni"
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 839.375
-	belt 1329
+	habitable 3143.73
+	belt 5237.89
 	haze _menu/haze-133
 	link Alderamin
 	link Altair
@@ -7849,32 +7849,32 @@ system "Delta Capricorni"
 	fleet "Human Miners" 3000
 	object
 		sprite star/g5
-		distance 29.7539
+		distance 79.25
 		period 17.3608
 	object
 		sprite star/m0
-		distance 86.7461
+		distance 256.17
 		period 17.3608
 		offset 180
 	object
 		sprite planet/io
-		distance 273.406
+		distance 907.76
 		period 62.4158
 	object Maker
 		sprite planet/rock4
-		distance 498.016
+		distance 1762.26
 		period 153.443
 	object
 		sprite planet/tethys
-		distance 898.776
+		distance 3391.64
 		period 372.014
 	object
 		sprite planet/cloud4-b
-		distance 1338.19
+		distance 5278.18
 		period 675.86
 	object
 		sprite planet/rock0-b
-		distance 3430.88
+		distance 15064.54
 		period 2774.53
 
 system "Delta Sagittarii"
@@ -7882,8 +7882,8 @@ system "Delta Sagittarii"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1414
+	habitable 1080.19
+	belt 5611.75
 	haze _menu/haze-133
 	link Rastaban
 	link "Alpha Arae"
@@ -7918,11 +7918,11 @@ system "Delta Sagittarii"
 		period 10
 	object "New Portland"
 		sprite planet/ocean6
-		distance 259.64
+		distance 857.4
 		period 93.5497
 	object
 		sprite planet/uranus
-		distance 911.2
+		distance 3443.74
 		period 615.043
 		object
 			sprite planet/dust2-b
@@ -7934,7 +7934,7 @@ system "Delta Sagittarii"
 			period 30.8334
 	object
 		sprite planet/gas9
-		distance 2036.41
+		distance 8421.91
 		period 2054.86
 		object
 			sprite planet/rock3-b
@@ -7950,8 +7950,8 @@ system "Delta Velorum"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1221
+	habitable 4159.2
+	belt 4766.87
 	haze _menu/haze-67
 	link Turais
 	link Fala
@@ -7986,7 +7986,7 @@ system "Delta Velorum"
 		period 10
 	object
 		sprite planet/rock18
-		distance 314.21
+		distance 1058.6
 		period 67.7919
 		object
 			sprite planet/dust2
@@ -7994,23 +7994,23 @@ system "Delta Velorum"
 			period 27.0988
 	object
 		sprite planet/desert6
-		distance 750.65
+		distance 2777.18
 		period 250.325
 	object Bounty
 		sprite planet/cloud2
-		distance 1276.69
+		distance 5009.18
 		period 555.234
 	object
 		sprite planet/dust1
-		distance 2244.94
+		distance 9388.02
 		period 1294.66
 
 system Deneb
 	pos -348 225
 	government Pug
 	arrival 1500
-	habitable 625
-	belt 1890
+	habitable 2266.58
+	belt 7750.45
 	haze _menu/haze-133
 	asteroids "small rock" 4 4.62
 	asteroids "medium rock" 192 8.82
@@ -8038,7 +8038,7 @@ system Deneb
 		period 10
 	object Pugglemug
 		sprite planet/ocean2
-		distance 317.56
+		distance 1071.09
 		period 90.5438
 		object
 			sprite planet/dust3
@@ -8046,7 +8046,7 @@ system Deneb
 			period 16.3701
 	object Pugglequat
 		sprite planet/desert3
-		distance 966.8
+		distance 3677.85
 		period 480.978
 		object
 			sprite planet/rhea-b
@@ -8054,11 +8054,11 @@ system Deneb
 			period 18.6328
 	object
 		sprite planet/dust7
-		distance 1538.84
+		distance 6165.55
 		period 965.851
 	object
 		sprite planet/dust0-b
-		distance 1788.4
+		distance 7288.04
 		period 1210.09
 
 system Denebola
@@ -8066,8 +8066,8 @@ system Denebola
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 534.375
-	belt 1050
+	habitable 1905.33
+	belt 4031.04
 	haze _menu/haze-67
 	link Sol
 	link Merak
@@ -8096,28 +8096,28 @@ system Denebola
 	fleet "Large Republic" 2000
 	object
 		sprite star/k5
-		distance 41.5211
+		distance 114.13
 		period 18.22
 		offset 180
 	object
 		sprite star/m0
-		distance 61.9789
+		distance 177.08
 		period 18.22
 	object
 		sprite planet/cloud3-b
-		distance 360.519
+		distance 1232.42
 		period 118.448
 	object Geyser
 		sprite planet/ice2
-		distance 628.609
+		distance 2281.09
 		period 272.714
 	object
 		sprite planet/rock0-b
-		distance 1051.05
+		distance 4035.52
 		period 589.619
 	object
 		sprite planet/gas1-b
-		distance 1550.34
+		distance 6216.84
 		period 1056.27
 		object
 			sprite planet/oberon
@@ -8125,7 +8125,7 @@ system Denebola
 			period 14.2774
 	object
 		sprite planet/io-b
-		distance 2927.23
+		distance 12619.5
 		period 2740.45
 
 system Diespiter
@@ -8133,7 +8133,7 @@ system Diespiter
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	arrival 1500
-	habitable 534.375
+	habitable 1905.33
 	haze _menu/haze-red
 	link Statina
 	asteroids "small rock" 65 3
@@ -8152,15 +8152,15 @@ system Diespiter
 		period 10
 	object
 		sprite planet/ice6
-		distance 745
+		distance 2754.0
 		period 394
 	object
 		sprite planet/lava0
-		distance 922
+		distance 3489.09
 		period 543
 	object
 		sprite planet/gas11
-		distance 1600
+		distance 6438.8
 		period 398
 		object
 			sprite planet/rock3
@@ -8172,8 +8172,8 @@ system Diphda
 	government Syndicate
 	attributes "near earth"
 	arrival 1500
-	habitable 590.625
-	belt 1559
+	habitable 2128.81
+	belt 6255.49
 	haze _menu/haze-133
 	link Ankaa
 	link Caph
@@ -8202,28 +8202,28 @@ system Diphda
 	fleet "Small Syndicate" 3000
 	object
 		sprite star/k0
-		distance 20.9143
+		distance 53.91
 		period 14.4057
 	object
 		sprite star/m4
-		distance 70.5857
+		distance 204.25
 		period 14.4057
 		offset 180
 	object
 		sprite planet/lava3-b
-		distance 264.586
+		distance 875.46
 		period 70.8359
 	object Tinker
 		sprite planet/forest5
-		distance 548.586
+		distance 1961.55
 		period 211.481
 	object
 		sprite planet/ice0-b
-		distance 1089.88
+		distance 4201.49
 		period 592.202
 	object
 		sprite planet/rock0-b
-		distance 2262.04
+		distance 9467.73
 		period 1770.73
 
 system Dixere
@@ -8232,7 +8232,7 @@ system Dixere
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 851.84
+	habitable 3195.59
 	link Delia
 	link Feraticus
 	link Giribea
@@ -8260,31 +8260,31 @@ system Dixere
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/k0-old
-		distance 43
+		distance 118.59
 		period 10.9302
 	object
 		sprite planet/lava1
-		distance 169.69
+		distance 536.22
 		period 30.2946
 		offset 260.355
 	object Veliante
 		sprite planet/lava4
-		distance 867.18
+		distance 3259.54
 		period 349.981
 		offset 344.167
 	object
 		sprite planet/desert2-b
-		distance 1104.67
+		distance 4264.89
 		period 503.187
 		offset 180.723
 	object
 		sprite planet/desert8
-		distance 1415.76
+		distance 5619.52
 		period 730.072
 		offset 333.491
 	object
 		sprite planet/gas8
-		distance 2132.25
+		distance 8864.56
 		period 1349.39
 		offset 141.543
 		object
@@ -8309,8 +8309,8 @@ system Dokdobaru
 	government Quarg
 	attributes "korath" "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1935
+	habitable 2570.09
+	belt 7956.2
 	haze _menu/haze-133
 	link Hesselpost
 	link Kashikt
@@ -8343,70 +8343,70 @@ system Dokdobaru
 		period 10
 	object "Korati Efreti"
 		sprite planet/station1k
-		distance 680
+		distance 2488.78
 		period 360
 	object
 		sprite planet/lava3-b
-		distance 812
+		distance 3030.14
 		period 360
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -30
 	object "Kuwaru Efreti"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset -50
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset -70
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -90
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 40
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 60
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 80
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 130
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 150
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 220
 
@@ -8415,8 +8415,8 @@ system Dschubba
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 398.125
-	belt 1429
+	habitable 1375.41
+	belt 5678.0
 	link Atria
 	link Lesath
 	link Alniyat
@@ -8449,32 +8449,32 @@ system Dschubba
 	fleet "Human Miners" 2000
 	object
 		sprite star/k5
-		distance 18.9364
+		distance 48.37
 		period 19.0038
 		offset 180
 	object
 		sprite star/m8
-		distance 77.5636
+		distance 226.54
 		period 19.0038
 	object Sundrinker
 		sprite planet/ocean1
-		distance 282.314
+		distance 940.49
 		period 95.0929
 	object
 		sprite planet/dust1-b
-		distance 523.674
+		distance 1863.1
 		period 240.238
 	object
 		sprite planet/rock1
-		distance 824.964
+		distance 3083.88
 		period 475.01
 	object
 		sprite planet/desert9
-		distance 1627.57
+		distance 6562.38
 		period 1316.32
 	object
 		sprite planet/gas17
-		distance 2816.33
+		distance 12087.53
 		period 2996.24
 		object
 			sprite planet/miranda
@@ -8490,8 +8490,8 @@ system Dubhe
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 349.375
-	belt 1120
+	habitable 1190.35
+	belt 4330.71
 	link Zosma
 	asteroids "medium rock" 12 3.5496
 	asteroids "large rock" 1 3.48
@@ -8519,36 +8519,36 @@ system Dubhe
 	fleet "Large Northern Pirates" 8000
 	object
 		sprite star/m0
-		distance 42.6977
+		distance 117.68
 		period 24.8575
 		offset 180
 	object
 		sprite star/m4
-		distance 67.8023
+		distance 195.43
 		period 24.8575
 	object Haze
 		sprite planet/forest1
-		distance 267.842
+		distance 887.37
 		period 93.8065
 	object
 		sprite planet/rock10
-		distance 696.682
+		distance 2556.58
 		period 393.52
 	object
 		sprite planet/lava3-b
-		distance 1485.44
+		distance 5928.0
 		period 1225.17
 	object
 		sprite planet/rock3-b
-		distance 2503.28
+		distance 10599.57
 		period 2680.27
 
 system "Due Yoot"
 	pos -167.547 -426.683
 	government Hai
 	arrival 1500
-	habitable 233.28
-	belt 1854
+	habitable 761.8
+	belt 7586.26
 	link "Wah Oh"
 	link "Io Mann"
 	link "Heia Due"
@@ -8581,23 +8581,23 @@ system "Due Yoot"
 		period 10
 	object Greenbloom
 		sprite planet/cloud3
-		distance 204.76
+		distance 659.68
 		period 76.7342
 	object
 		sprite planet/ganymede
-		distance 391.65
+		distance 1350.68
 		period 202.987
 	object
 		sprite planet/lava4-b
-		distance 643.34
+		distance 2340.44
 		period 427.348
 	object
 		sprite planet/mercury-b
-		distance 1042.35
+		distance 3998.43
 		period 881.336
 	object
 		sprite planet/gas15
-		distance 2335.56
+		distance 9811.22
 		period 2956.02
 		object
 			sprite planet/callisto-b
@@ -8613,8 +8613,8 @@ system Durax
 	government Pirate
 	attributes "core"
 	arrival 1500
-	habitable 1080
-	belt 1287
+	habitable 4159.2
+	belt 5054.17
 	haze _menu/haze-133
 	link Alcyone
 	asteroids "small rock" 16 8.1744
@@ -8643,11 +8643,11 @@ system Durax
 		period 10
 	object
 		sprite planet/rock16-b
-		distance 206.84
+		distance 667.08
 		period 36.2076
 	object
 		sprite planet/gas15
-		distance 951.09
+		distance 3611.54
 		period 357.01
 		object
 			sprite planet/lava2
@@ -8659,11 +8659,11 @@ system Durax
 			period 33.2479
 	object
 		sprite planet/ice8
-		distance 1740.09
+		distance 7069.23
 		period 883.498
 	object
 		sprite planet/gas2
-		distance 2530.73
+		distance 10729.2
 		period 1549.59
 		object
 			sprite planet/lava0
@@ -8679,8 +8679,8 @@ system Eber
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1199
+	habitable 1080.19
+	belt 4671.5
 	link Alnasl
 	link "Alpha Arae"
 	asteroids "small rock" 18 1.4868
@@ -8712,7 +8712,7 @@ system Eber
 		period 10
 	object
 		sprite planet/gas4-b
-		distance 428.49
+		distance 1491.98
 		period 198.333
 		object
 			sprite planet/dust3-b
@@ -8724,11 +8724,11 @@ system Eber
 			period 19.6268
 	object
 		sprite planet/io
-		distance 957.74
+		distance 3639.59
 		period 662.76
 	object
 		sprite planet/gas15
-		distance 1468.3
+		distance 5851.96
 		period 1258.08
 		object
 			sprite planet/mercury-b
@@ -8736,7 +8736,7 @@ system Eber
 			period 17.5306
 	object
 		sprite planet/gas0-b
-		distance 2248.11
+		distance 9402.79
 		period 2383.48
 
 system Eblumab
@@ -8744,8 +8744,8 @@ system Eblumab
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 425.92
-	belt 1804
+	habitable 1482.07
+	belt 7358.85
 	haze _menu/haze-133
 	link Blugtad
 	asteroids "small rock" 10 7.8364
@@ -8779,11 +8779,11 @@ system Eblumab
 		period 10
 	object "Factory of Eblumab"
 		sprite planet/cloud2
-		distance 294.861
+		distance 986.79
 		period 98.1345
 	object
 		sprite planet/fog0
-		distance 789.318
+		distance 2936.36
 		period 429.808
 		object
 			sprite planet/ice7-b
@@ -8791,7 +8791,7 @@ system Eblumab
 			period 20.0877
 	object
 		sprite planet/desert2-b
-		distance 1262.96
+		distance 4949.32
 		period 869.92
 		object
 			sprite planet/tethys-b
@@ -8799,7 +8799,7 @@ system Eblumab
 			period 21.1965
 	object
 		sprite planet/uranus-b
-		distance 2384.24
+		distance 10039.37
 		period 2256.42
 		object
 			sprite planet/rock14
@@ -8811,8 +8811,8 @@ system Edusa
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 2372.76
-	belt 1167
+	habitable 9985.52
+	belt 4533.13
 	haze _menu/haze-red
 	link Arculus
 	asteroids "small rock" 2 0.740133
@@ -8841,23 +8841,23 @@ system Edusa
 		period 10
 	object
 		sprite planet/ice4
-		distance 211.61
+		distance 684.07
 		period 25.2777
 	object
 		sprite planet/desert10-b
-		distance 423.82
+		distance 1473.99
 		period 71.6482
 	object
 		sprite planet/rock19-b
-		distance 680.82
+		distance 2492.11
 		period 145.875
 	object
 		sprite planet/dust4
-		distance 981.71
+		distance 3740.89
 		period 252.585
 	object "Remnant Wormhole"
 		sprite planet/wormhole-red
-		distance 3465.15
+		distance 15232.55
 		period 1675.01
 
 system Egeria
@@ -8865,7 +8865,7 @@ system Egeria
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	arrival 1500
-	habitable 1505.92
+	habitable 6018.99
 	haze _menu/haze-red
 	link Vaticanus
 	link Statina
@@ -8880,20 +8880,20 @@ system Egeria
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/k5-old
-		distance 40
+		distance 109.56
 		offset 180
 		period 19
 	object
 		sprite star/g0
-		distance 74
+		distance 215.13
 		period 19
 	object
 		sprite planet/ice4
-		distance 248
+		distance 815.05
 		period 61
 	object
 		sprite planet/gas9
-		distance 1326
+		distance 5224.75
 		period 2174
 		object
 			sprite planet/rhea
@@ -8904,8 +8904,8 @@ system "Ehma Ti"
 	pos 39.1085 -749.244
 	government "Hai (Unfettered)"
 	arrival 1500
-	habitable 486.68
-	belt 1094
+	habitable 1717.88
+	belt 4219.14
 	link "Wah Yoot"
 	asteroids "small rock" 1 3.276
 	asteroids "medium rock" 1 1.7472
@@ -8933,15 +8933,15 @@ system "Ehma Ti"
 		period 10
 	object
 		sprite planet/lava5
-		distance 140.21
+		distance 434.51
 		period 30.1028
 	object Firelode
 		sprite planet/rock4
-		distance 481.46
+		distance 1697.49
 		period 191.548
 	object
 		sprite planet/gas17
-		distance 1361.82
+		distance 5381.93
 		period 911.209
 		object
 			sprite planet/callisto
@@ -8957,7 +8957,7 @@ system "Ehma Ti"
 			period 46.0578
 	object
 		sprite planet/gas1
-		distance 2334.98
+		distance 9808.51
 		period 2045.8
 		object
 			sprite planet/rhea-b
@@ -8972,8 +8972,8 @@ system Ek'kek'ru
 	pos -287.517 -727.738
 	government Wanderer
 	arrival 1500
-	habitable 320
-	belt 1517
+	habitable 1080.19
+	belt 6068.28
 	haze _menu/haze-none
 	link Ka'ch'chrai
 	link Si'yak'ku
@@ -9005,7 +9005,7 @@ system Ek'kek'ru
 		period 10
 	object "Kort Kehai"
 		sprite planet/rock13
-		distance 287.96
+		distance 961.3
 		period 109.266
 		object
 			sprite planet/ice0
@@ -9013,11 +9013,11 @@ system Ek'kek'ru
 			period 27.3733
 	object
 		sprite planet/lava4-b
-		distance 804.65
+		distance 2999.72
 		period 510.382
 	object
 		sprite planet/uranus-b
-		distance 1667.41
+		distance 6741.39
 		period 1522.47
 		object
 			sprite planet/oberon
@@ -9025,7 +9025,7 @@ system Ek'kek'ru
 			period 12.909
 	object
 		sprite planet/gas7-b
-		distance 2129.85
+		distance 8853.44
 		period 2197.9
 
 system Ekuarik
@@ -9033,8 +9033,8 @@ system Ekuarik
 	government Heliarch
 	attributes "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1711
+	habitable 2570.09
+	belt 6937.82
 	link "Ki War Ek"
 	link Quaru
 	link Belug
@@ -9069,146 +9069,146 @@ system Ekuarik
 		period 10
 	object
 		sprite planet/lava6-b
-		distance 812
+		distance 3030.14
 		period 360
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 30
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 50
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 75
 	object "Ring of Wisdom"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 95
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 115
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 150
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 170
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object "Ring of Wisdom"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 220
 	object "Ring of Wisdom"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 240
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 260
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 280
 	object "Ring of Wisdom"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 300
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 320
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 82
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 90
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 99
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 112
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 207
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 216
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 225
 	object
 		sprite planet/panels4
-		distance 800
+		distance 2980.49
 		period 360
 		offset 234
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 221
 	object
 		sprite planet/panels5
-		distance 830
+		distance 3104.78
 		period 360
 		offset 239
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 253
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 281
 	object
 		sprite planet/panels4
-		distance 800
+		distance 2980.49
 		period 360
 		offset 298
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 312
 
@@ -9217,8 +9217,8 @@ system Elnath
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1715
-	belt 1462
+	habitable 6955.87
+	belt 5824.04
 	link Acamar
 	link Aldebaran
 	link Nihal
@@ -9251,11 +9251,11 @@ system Elnath
 		period 10
 	object
 		sprite planet/rock13
-		distance 198.64
+		distance 637.96
 		period 27.0413
 	object
 		sprite planet/water1
-		distance 683.13
+		distance 2501.49
 		period 172.458
 		object
 			sprite planet/ganymede-b
@@ -9263,15 +9263,15 @@ system Elnath
 			period 21.047
 	object
 		sprite planet/cloud1
-		distance 1147.13
+		distance 4447.44
 		period 375.273
 	object Pilot
 		sprite planet/desert4
-		distance 1926.02
+		distance 7915.1
 		period 816.43
 	object
 		sprite planet/gas11
-		distance 4745.58
+		distance 21639.59
 		period 3157.63
 		object "Carbuncle Station"
 			sprite planet/station9
@@ -9283,8 +9283,8 @@ system Eltanin
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 455.625
-	belt 1859
+	habitable 1596.92
+	belt 7609.05
 	haze _menu/haze-133
 	link Dabih
 	link "Delta Sagittarii"
@@ -9316,11 +9316,11 @@ system Eltanin
 		period 10
 	object
 		sprite planet/cloud5
-		distance 258.11
+		distance 851.82
 		period 77.7076
 	object
 		sprite planet/rock4-b
-		distance 641.75
+		distance 2334.02
 		period 304.653
 		object
 			sprite planet/tethys
@@ -9328,15 +9328,15 @@ system Eltanin
 			period 13.6705
 	object
 		sprite planet/gas13
-		distance 1242.91
+		distance 4862.05
 		period 821.137
 	object
 		sprite planet/ice8-b
-		distance 1843.16
+		distance 7536.9
 		period 1482.86
 	object
 		sprite planet/rock17
-		distance 2165.97
+		distance 9020.86
 		period 1889.01
 
 system Eneremprukt
@@ -9344,8 +9344,8 @@ system Eneremprukt
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1421
+	habitable 1717.88
+	belt 5642.66
 	link Silikatakfar
 	link Mesuket
 	link Ferukistek
@@ -9373,15 +9373,15 @@ system Eneremprukt
 		period 10
 	object
 		sprite planet/desert7
-		distance 210.96
+		distance 681.75
 		period 55.557
 	object "Sopi Lefarkata"
 		sprite planet/ice3
-		distance 589.2
+		distance 2123.12
 		period 259.318
 	object
 		sprite planet/gas17-b
-		distance 1477.84
+		distance 5894.27
 		period 1030.1
 		object
 			sprite planet/io-b
@@ -9393,7 +9393,7 @@ system Eneremprukt
 			period 27.0217
 	object
 		sprite planet/gas6-b
-		distance 2137.8
+		distance 8890.26
 		period 1792.21
 
 system Enif
@@ -9401,8 +9401,8 @@ system Enif
 	government Quarg
 	attributes "south" "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1974
+	habitable 2570.09
+	belt 8134.97
 	link Sadalmelik
 	link Sadalsuud
 	link Tarazed
@@ -9433,56 +9433,56 @@ system Enif
 		period 10
 	object
 		sprite planet/lava5-b
-		distance 812
+		distance 3030.14
 		period 360
 	object Lagrange
 		sprite planet/station0
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -30
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset -50
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -70
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -90
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset -110
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 40
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 60
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 80
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 100
 
@@ -9491,8 +9491,8 @@ system "Epsilon Leonis"
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 1400
-	belt 1527
+	habitable 5549.99
+	belt 6112.8
 	link Gomeisa
 	link Aspidiske
 	link Adhara
@@ -9522,16 +9522,16 @@ system "Epsilon Leonis"
 	fleet "Republic Logistics" 6000
 	object
 		sprite star/g0
-		distance 25.8286
+		distance 67.89
 		period 12.8414
 		offset 180
 	object
 		sprite star/k5
-		distance 87.1714
+		distance 257.56
 		period 12.8414
 	object
 		sprite planet/ice4-b
-		distance 403.211
+		distance 1394.87
 		period 86.5556
 		object
 			sprite planet/ice8-b
@@ -9539,15 +9539,15 @@ system "Epsilon Leonis"
 			period 17.5024
 	object
 		sprite planet/ganymede-b
-		distance 747.171
+		distance 2762.9
 		period 218.337
 	object Valhalla
 		sprite planet/earth
-		distance 1027.21
+		distance 3933.96
 		period 351.954
 	object
 		sprite planet/gas7
-		distance 2086.25
+		distance 8651.8
 		period 1018.7
 		object
 			sprite planet/dust1
@@ -9566,8 +9566,8 @@ system Es'sprak'ai
 	pos -469.044 -733.375
 	government Wanderer
 	arrival 1500
-	habitable 486.68
-	belt 1928
+	habitable 1717.88
+	belt 7924.16
 	haze _menu/haze-none
 	link Pik'ro'iyak
 	asteroids "small rock" 3 2.2275
@@ -9596,11 +9596,11 @@ system Es'sprak'ai
 		period 10
 	object
 		sprite planet/cloud4-b
-		distance 168.84
+		distance 533.26
 		period 39.7788
 	object "Vara Rakak"
 		sprite planet/cloud6
-		distance 498.48
+		distance 1764.08
 		period 201.795
 		object
 			sprite planet/tethys-b
@@ -9608,7 +9608,7 @@ system Es'sprak'ai
 			period 14.6525
 	object
 		sprite planet/rock4-b
-		distance 1009.57
+		distance 3858.99
 		period 581.625
 		object
 			sprite planet/rhea-b
@@ -9616,7 +9616,7 @@ system Es'sprak'ai
 			period 17.9093
 	object
 		sprite planet/gas5-b
-		distance 2576.18
+		distance 10944.2
 		period 2370.84
 		object
 			sprite planet/miranda
@@ -9628,8 +9628,8 @@ system Eshkoshtar
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 806.68
-	belt 1105
+	habitable 3008.12
+	belt 4266.31
 	link Mekislepti
 	link Similisti
 	link Mesuket
@@ -9657,16 +9657,16 @@ system Eshkoshtar
 	fleet "Kor Mereti Miners" 3000
 	object
 		sprite star/k0
-		distance 47.9992
+		distance 133.79
 		period 18.7451
 		offset 180
 	object
 		sprite star/m0
-		distance 73.0008
+		distance 211.94
 		period 18.7451
 	object
 		sprite planet/neptune
-		distance 403.411
+		distance 1395.64
 		period 114.112
 		object
 			sprite planet/luna
@@ -9674,11 +9674,11 @@ system Eshkoshtar
 			period 15.5974
 	object "Esayaku Fen"
 		sprite planet/desert10
-		distance 796.251
+		distance 2964.99
 		period 316.435
 	object
 		sprite planet/gas11-b
-		distance 1598.86
+		distance 6433.7
 		period 900.379
 		object
 			sprite planet/station2kd
@@ -9687,7 +9687,7 @@ system Eshkoshtar
 			offset 203.816
 	object
 		sprite planet/gas4
-		distance 2400.09
+		distance 10113.77
 		period 1655.96
 		object
 			sprite planet/rock14-b
@@ -9704,7 +9704,7 @@ system Esix
 	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 8640
+	habitable 42290.44
 	link Gerenus
 	link Nona
 	link Paeli
@@ -9732,19 +9732,19 @@ system Esix
 		period 10
 	object
 		sprite planet/desert7-b
-		distance 245.01
+		distance 804.2
 		period 132.029
 	object
 		sprite planet/dust5-b
-		distance 593.57
+		distance 2140.58
 		period 497.853
 	object
 		sprite planet/gas5
-		distance 945.38
+		distance 3587.47
 		period 1000.7
 	object
 		sprite planet/gas3
-		distance 2694.88
+		distance 11507.81
 		period 4816.17
 		offset 47.9894
 		object
@@ -9757,7 +9757,7 @@ system Esix
 			period 18.3265
 	object "Graveyard Wormhole (Unstable)"
 		sprite planet/wormhole-red
-		distance 3618.74
+		distance 15987.92
 		period 2242.12
 		offset 278.315
 
@@ -9766,8 +9766,8 @@ system Eteron
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 135
-	belt 1479
+	habitable 416.76
+	belt 5899.42
 	link Sirius
 	link Caph
 	asteroids "small rock" 30 2.688
@@ -9800,7 +9800,7 @@ system Eteron
 		period 10
 	object
 		sprite planet/rock9
-		distance 358.76
+		distance 1225.77
 		period 233.937
 		object
 			sprite planet/ganymede
@@ -9808,7 +9808,7 @@ system Eteron
 			period 27.7867
 	object
 		sprite planet/uranus
-		distance 1126.76
+		distance 4359.76
 		period 1302.09
 		object
 			sprite planet/dust1-b
@@ -9820,19 +9820,19 @@ system Eteron
 			period 28.2485
 	object
 		sprite planet/ice0-b
-		distance 1751.6
+		distance 7121.3
 		period 2523.75
 	object
 		sprite planet/gas17-b
-		distance 2229.85
+		distance 9317.74
 		period 3624.99
 
 system "Fah Root"
 	pos -264.065 -400.135
 	government Hai
 	arrival 1500
-	habitable 486.68
-	belt 1057
+	habitable 1717.88
+	belt 4060.91
 	haze _menu/haze-67
 	link "Wah Oh"
 	asteroids "small rock" 15 2.1735
@@ -9865,23 +9865,23 @@ system "Fah Root"
 		period 10
 	object
 		sprite planet/rock19-b
-		distance 172.04
+		distance 544.41
 		period 40.915
 	object Darkwaste
 		sprite planet/rock18
-		distance 527.8
+		distance 1879.37
 		period 219.858
 	object
 		sprite planet/rock15
-		distance 933.8
+		distance 3538.71
 		period 517.391
 	object
 		sprite planet/europa
-		distance 1148.24
+		distance 4452.22
 		period 705.484
 	object
 		sprite planet/gas4
-		distance 3187
+		distance 13874.83
 		period 3262.21
 		object
 			sprite planet/tethys
@@ -9900,8 +9900,8 @@ system "Fah Soom"
 	pos -179.891 -335.011
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1185
+	habitable 1482.07
+	belt 4610.91
 	haze _menu/haze-67
 	link "Hevru Hai"
 	link "Wah Oh"
@@ -9934,7 +9934,7 @@ system "Fah Soom"
 		period 10
 	object Greenwater
 		sprite planet/cloud1
-		distance 365
+		distance 1249.38
 		period 135.156
 		object
 			sprite planet/dust5
@@ -9942,11 +9942,11 @@ system "Fah Soom"
 			period 17.3053
 	object
 		sprite planet/lava3
-		distance 884.21
+		distance 3330.67
 		period 509.6
 	object
 		sprite planet/gas3-b
-		distance 1760.62
+		distance 7162.13
 		period 1431.84
 		object
 			sprite planet/rock14-b
@@ -9962,8 +9962,8 @@ system Fala
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 625
-	belt 1264
+	habitable 2266.58
+	belt 4953.85
 	link "Tania Australis"
 	link "Delta Velorum"
 	asteroids "small rock" 2 3.0464
@@ -9996,15 +9996,15 @@ system Fala
 		period 10
 	object
 		sprite planet/desert1-b
-		distance 226.84
+		distance 738.61
 		period 54.6638
 	object
 		sprite planet/desert3-b
-		distance 584
+		distance 2102.36
 		period 225.808
 	object
 		sprite planet/ice1
-		distance 1127.25
+		distance 4361.87
 		period 605.55
 		object
 			sprite planet/europa
@@ -10012,7 +10012,7 @@ system Fala
 			period 17.4178
 	object
 		sprite planet/gas16
-		distance 2666.29
+		distance 11371.79
 		period 2202.83
 		object
 			sprite planet/dust4
@@ -10024,8 +10024,8 @@ system "Fallen Leaf"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 320
-	belt 1327
+	habitable 1080.19
+	belt 5229.13
 	link Beginning
 	asteroids "large metal" 1 7.748
 	trade Clothing 310
@@ -10050,23 +10050,23 @@ system "Fallen Leaf"
 		period 10
 	object
 		sprite planet/lava7-b
-		distance 131.69
+		distance 405.52
 		period 33.792
 	object "Shadowed Valley"
 		sprite planet/ocean1
-		distance 369.65
+		distance 1266.99
 		period 158.917
 	object
 		sprite planet/rock8-b
-		distance 640.54
+		distance 2329.15
 		period 362.497
 	object
 		sprite planet/rock15
-		distance 1431.55
+		distance 5689.27
 		period 1211.14
 	object
 		sprite planet/desert0
-		distance 1920.55
+		distance 7890.07
 		period 1882.02
 		object
 			sprite planet/rock7
@@ -10078,8 +10078,8 @@ system "Far Horizon"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 320
-	belt 1242
+	habitable 1080.19
+	belt 4858.1
 	haze _menu/haze-67
 	link Companion
 	link "Ancient Hope"
@@ -10107,15 +10107,15 @@ system "Far Horizon"
 		period 10
 	object
 		sprite planet/tethys-b
-		distance 99.44
+		distance 297.68
 		period 22.1731
 	object "Secret Sky"
 		sprite planet/cloud3
-		distance 367.6
+		distance 1259.22
 		period 157.597
 	object
 		sprite planet/ice5
-		distance 821.09
+		distance 3067.81
 		period 526.103
 		object
 			sprite planet/rock14-b
@@ -10123,7 +10123,7 @@ system "Far Horizon"
 			period 20.2055
 	object
 		sprite planet/uranus
-		distance 1859.34
+		distance 7610.6
 		period 1792.76
 		object
 			sprite planet/ice0-b
@@ -10135,8 +10135,8 @@ system Farbutero
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 625
-	belt 1175
+	habitable 2266.58
+	belt 4567.69
 	haze _menu/haze-133
 	link Meftarkata
 	link Feroteri
@@ -10167,11 +10167,11 @@ system Farbutero
 		period 10
 	object
 		sprite planet/rock6
-		distance 180.25
+		distance 573.13
 		period 38.7198
 	object "Solima Skarati"
 		sprite planet/cloud3
-		distance 668.54
+		distance 2442.31
 		period 276.574
 		object
 			sprite planet/rock3
@@ -10179,11 +10179,11 @@ system Farbutero
 			period 25.456
 	object
 		sprite planet/cloud4
-		distance 1129.7
+		distance 4372.41
 		period 607.526
 	object
 		sprite planet/gas15-b
-		distance 1651.04
+		distance 6667.78
 		period 1073.39
 		object
 			sprite planet/station2kd
@@ -10191,7 +10191,7 @@ system Farbutero
 			period 18.0122
 	object
 		sprite planet/gas11
-		distance 3202.36
+		distance 13949.44
 		period 2899.52
 		object
 			sprite planet/rock7-b
@@ -10211,8 +10211,8 @@ system Farinus
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 745.92
-	belt 1149
+	habitable 2757.77
+	belt 4455.5
 	haze _menu/haze-red
 	link Cinxia
 	link Perfica
@@ -10236,20 +10236,20 @@ system Farinus
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/k5-old
-		distance 36.894
+		distance 100.28
 		period 11.6805
 	object
 		sprite star/m0
-		distance 49.106
+		distance 137.17
 		period 11.6805
 		offset 180
 	object
 		sprite planet/gas7-hot
-		distance 195.066
+		distance 625.3
 		period 39.9012
 	object
 		sprite planet/mars
-		distance 524.316
+		distance 1865.64
 		period 175.834
 		object
 			sprite planet/dust4-b
@@ -10257,7 +10257,7 @@ system Farinus
 			period 20.499
 	object
 		sprite planet/gas17
-		distance 1311.33
+		distance 5160.52
 		period 695.472
 		object
 			sprite planet/callisto
@@ -10273,7 +10273,7 @@ system Farinus
 			period 46.9098
 	object
 		sprite planet/jupiter-b
-		distance 2113.37
+		distance 8777.17
 		period 1422.91
 		object
 			sprite planet/dust0
@@ -10285,8 +10285,8 @@ system Faronektu
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 1080
-	belt 1630
+	habitable 4159.2
+	belt 6573.29
 	haze _menu/haze-133
 	link Similisti
 	link Salipastart
@@ -10317,11 +10317,11 @@ system Faronektu
 		period 10
 	object
 		sprite planet/rock16-b
-		distance 165.44
+		distance 521.43
 		period 25.9005
 	object
 		sprite planet/gas8-b
-		distance 616.53
+		distance 2232.55
 		period 186.329
 		object
 			sprite planet/io
@@ -10329,7 +10329,7 @@ system Faronektu
 			period 13.7219
 	object
 		sprite planet/uranus
-		distance 1360.42
+		distance 5375.78
 		period 610.739
 		offset 126.212
 		object "Fara Skaeruti"
@@ -10338,11 +10338,11 @@ system Faronektu
 			period 19.0508
 	object
 		sprite planet/desert0
-		distance 1968.77
+		distance 8110.97
 		period 1063.26
 	object
 		sprite planet/gas17-b
-		distance 3570.81
+		distance 15751.78
 		period 2597.15
 		object
 			sprite planet/rock0-b
@@ -10354,8 +10354,8 @@ system Fasitopfar
 	government Uninhabited
 	attributes "archon" "korath" "nova"
 	arrival 1500
-	habitable 100
-	belt 1670
+	habitable 299.53
+	belt 6753.04
 	haze _menu/haze-blackbody
 	asteroids "small rock" 24 7.722
 	asteroids "medium rock" 58 6.75
@@ -10381,19 +10381,19 @@ system Fasitopfar
 		period 1000
 	object
 		sprite planet/lava1
-		distance 863.513
+		distance 3244.24
 		period 491.812
 	object
 		sprite planet/lava6
-		distance 1181.27
+		distance 4594.78
 		period 786.9
 	object
 		sprite planet/rock4-b
-		distance 1471.99
+		distance 5868.32
 		period 1094.59
 	object
 		sprite planet/dust0-b
-		distance 1927.7
+		distance 7922.79
 		period 1640.42
 
 system Fearis
@@ -10402,7 +10402,7 @@ system Fearis
 	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 486.68
+	habitable 1717.88
 	link Feraticus
 	link Lire
 	asteroids "large metal" 1.9865 1.34234
@@ -10428,19 +10428,19 @@ system Fearis
 		period 10
 	object
 		sprite planet/rock14-b
-		distance 179.41
+		distance 570.18
 		period 43.5721
 	object
 		sprite planet/dust6
-		distance 351.57
+		distance 1198.63
 		period 119.524
 	object
 		sprite planet/ocean9-b
-		distance 651.93
+		distance 2375.11
 		period 301.814
 	object
 		sprite planet/rock2
-		distance 1046.89
+		distance 4017.78
 		period 614.172
 		object
 			sprite planet/luna-b
@@ -10448,7 +10448,7 @@ system Fearis
 			period 20.5678
 	object
 		sprite planet/jupiter-b
-		distance 2525.49
+		distance 10704.44
 		period 3795.49
 		offset 11.7572
 		object "Letis'sei"
@@ -10457,7 +10457,7 @@ system Fearis
 			period 11.83
 	object "Graveyard Wormhole (Stable)"
 		sprite planet/wormhole
-		distance 3606.64
+		distance 15928.27
 		period 1167.66
 		offset 195.653
 
@@ -10466,8 +10466,8 @@ system "Fell Omen"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 425.92
-	belt 1240
+	habitable 1482.07
+	belt 4849.4
 	link "Last Word"
 	asteroids "small rock" 30 6.3
 	asteroids "medium rock" 91 4.1832
@@ -10498,15 +10498,15 @@ system "Fell Omen"
 		period 10
 	object
 		sprite planet/cloud4
-		distance 179.81
+		distance 571.58
 		period 46.7323
 	object
 		sprite planet/dust2
-		distance 406.62
+		distance 1407.93
 		period 158.92
 	object "Cold Horizon"
 		sprite planet/forest1
-		distance 733.87
+		distance 2708.39
 		period 385.323
 		object
 			sprite planet/tethys-b
@@ -10514,7 +10514,7 @@ system "Fell Omen"
 			period 24.3888
 	object
 		sprite planet/gas11-b
-		distance 1560.63
+		distance 6262.76
 		period 1194.94
 		object
 			sprite planet/rock0
@@ -10526,7 +10526,7 @@ system "Fell Omen"
 			period 24.5282
 	object
 		sprite planet/gas14
-		distance 3654.64
+		distance 16165.04
 		period 4282.16
 		object
 			sprite planet/dust3-b
@@ -10543,7 +10543,7 @@ system Feraticus
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 320
+	habitable 1080.19
 	link Dixere
 	link Fearis
 	link Giribea
@@ -10575,17 +10575,17 @@ system Feraticus
 		period 10
 	object
 		sprite planet/rock0-b
-		distance 264.77
+		distance 876.13
 		period 96.3359
 		offset 339.997
 	object
 		sprite planet/lava0
-		distance 422.81
+		distance 1470.1
 		period 194.403
 		offset 81.6258
 	object
 		sprite planet/gas10-b
-		distance 893.22
+		distance 3368.37
 		period 596.929
 		offset 271.075
 		object
@@ -10598,7 +10598,7 @@ system Feraticus
 			period 21.9693
 	object
 		sprite planet/gas1-b
-		distance 2487.73
+		distance 10526.21
 		period 2774.54
 		offset 276.106
 
@@ -10608,7 +10608,7 @@ system Fereti
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 486.68
+	habitable 1717.88
 	link Lire
 	asteroids "large metal" 5 2
 	asteroids "large rock" 4 3
@@ -10636,11 +10636,11 @@ system Fereti
 		period 10
 	object
 		sprite planet/lava7
-		distance 152.36
+		distance 476.18
 		period 34.0992
 	object
 		sprite planet/desert5
-		distance 521.2
+		distance 1853.36
 		period 215.747
 		object
 			sprite planet/dust3-b
@@ -10648,11 +10648,11 @@ system Fereti
 			period 25.6804
 	object Parii'het
 		sprite planet/station2b
-		distance 1687.04
+		distance 6829.78
 		period 479.019
 	object
 		sprite planet/gas2
-		distance 2166.29
+		distance 9022.34
 		period 2087.09
 		object "Alix"
 			sprite planet/luna-b
@@ -10664,8 +10664,8 @@ system Feroteri
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 5425.92
-	belt 1419
+	habitable 25134.0
+	belt 5633.83
 	haze _menu/haze-blackbody
 	link Farbutero
 	link Korsmanath
@@ -10692,16 +10692,16 @@ system Feroteri
 	fleet "Large Kor Mereti" 6400
 	object
 		sprite star/a0
-		distance 9.18418
+		distance 21.99
 		period 6.8723
 		offset 180
 	object
 		sprite star/k5
-		distance 107.816
+		distance 325.38
 		period 6.8723
 	object
 		sprite planet/gas17-b
-		distance 732.656
+		distance 2703.42
 		period 107.689
 		object
 			sprite planet/dust7-b
@@ -10717,11 +10717,11 @@ system Feroteri
 			period 43.2556
 	object
 		sprite planet/gas4
-		distance 1509.07
+		distance 6033.0
 		period 318.336
 	object
 		sprite planet/gas0-b
-		distance 2528.08
+		distance 10716.68
 		period 690.253
 		object
 			sprite planet/rock3-b
@@ -10737,7 +10737,7 @@ system Feroteri
 			period 35.1523
 	object
 		sprite planet/gas16
-		distance 3770.57
+		distance 16738.42
 		period 1257.29
 		object "Esperaktu Station"
 			sprite planet/station1k
@@ -10749,8 +10749,8 @@ system Ferukistek
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1520
+	habitable 1717.88
+	belt 6081.63
 	link Eneremprukt
 	link Silikatakfar
 	asteroids "small rock" 1 1.072
@@ -10780,19 +10780,19 @@ system Ferukistek
 		period 10
 	object
 		sprite planet/rock3
-		distance 169.29
+		distance 534.82
 		period 39.9379
 	object "Keneska Fek"
 		sprite planet/rock12
-		distance 420.5
+		distance 1461.21
 		period 156.346
 	object
 		sprite planet/desert9-b
-		distance 903.74
+		distance 3412.45
 		period 492.61
 	object
 		sprite planet/gas11
-		distance 1704.99
+		distance 6910.7
 		period 1276.5
 		object
 			sprite planet/dust5-b
@@ -10804,8 +10804,8 @@ system Fingol
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 135
-	belt 1976
+	habitable 416.76
+	belt 8144.15
 	haze _menu/haze-none
 	link Denebola
 	asteroids "small rock" 3 2.992
@@ -10835,11 +10835,11 @@ system Fingol
 		period 10
 	object
 		sprite planet/cloud4
-		distance 216.25
+		distance 700.64
 		period 109.478
 	object
 		sprite planet/rock1-b
-		distance 575.14
+		distance 2067.04
 		period 474.847
 		object
 			sprite planet/ice7
@@ -10847,15 +10847,15 @@ system Fingol
 			period 16.5247
 	object
 		sprite planet/water0
-		distance 1017.78
+		distance 3893.87
 		period 1117.83
 	object
 		sprite planet/dust4-b
-		distance 1806.07
+		distance 7368.25
 		period 2642.38
 	object
 		sprite planet/rock3
-		distance 2463.48
+		distance 10411.91
 		period 4209.37
 
 system Flugbu
@@ -10863,8 +10863,8 @@ system Flugbu
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 425.92
-	belt 1843
+	habitable 1482.07
+	belt 7536.17
 	link Torbab
 	link Debrugt
 	asteroids "small rock" 92 4.0848
@@ -10897,19 +10897,19 @@ system Flugbu
 		period 10
 	object
 		sprite planet/ice2
-		distance 161.44
+		distance 507.55
 		period 39.7569
 	object "Stronghold of Flugbu"
 		sprite planet/ocean0
-		distance 437.4
+		distance 1526.36
 		period 177.302
 	object
 		sprite planet/titan
-		distance 795.29
+		distance 2961.02
 		period 434.695
 	object
 		sprite planet/gas6
-		distance 1577.1
+		distance 6336.35
 		period 1213.91
 		object
 			sprite planet/dust1
@@ -10929,8 +10929,8 @@ system Fomalhaut
 	government Syndicate
 	attributes "near earth"
 	arrival 1500
-	habitable 455.625
-	belt 1854
+	habitable 1596.92
+	belt 7586.26
 	link Altair
 	link Markab
 	asteroids "small rock" 3 7.1415
@@ -10961,15 +10961,15 @@ system Fomalhaut
 		period 10
 	object
 		sprite planet/lava4
-		distance 193.46
+		distance 619.63
 		period 50.4247
 	object Millrace
 		sprite planet/forest1
-		distance 437.87
+		distance 1528.17
 		period 171.701
 	object
 		sprite planet/gas9
-		distance 1365.12
+		distance 5396.43
 		period 945.176
 		object
 			sprite planet/lava2-b
@@ -10977,7 +10977,7 @@ system Fomalhaut
 			period 14.3618
 	object
 		sprite planet/gas10-b
-		distance 2203.28
+		distance 9194.13
 		period 1938.03
 		object
 			sprite planet/oberon-b
@@ -10993,8 +10993,8 @@ system Fornarep
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1922
+	habitable 1080.19
+	belt 7896.7
 	haze _menu/haze-133
 	link Skeruto
 	link Meftarkata
@@ -11026,7 +11026,7 @@ system Fornarep
 		period 10
 	object "Sek Alarfarat"
 		sprite planet/rock4
-		distance 338.809
+		distance 1150.61
 		period 139.45
 		object
 			sprite planet/station1kd
@@ -11034,17 +11034,17 @@ system Fornarep
 			period 22.5265
 	object
 		sprite planet/gas9
-		distance 985.84
+		distance 3758.38
 		period 692.141
 		offset 296.234
 	object
 		sprite planet/rock5
-		distance 1479.93
+		distance 5903.55
 		period 1273.05
 		offset 94.342
 	object
 		sprite planet/gas17
-		distance 2002.34
+		distance 8265.14
 		period 2003.51
 		offset 41.653
 		object
@@ -11061,8 +11061,8 @@ system "Four Pillars"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 486.68
-	belt 1061
+	habitable 1717.88
+	belt 4077.98
 	link "Far Horizon"
 	link "Lone Cloud"
 	asteroids "small rock" 9 4.851
@@ -11096,23 +11096,23 @@ system "Four Pillars"
 		period 10
 	object
 		sprite planet/rock6
-		distance 216.89
+		distance 702.93
 		period 57.9159
 	object "Flowing Fields"
 		sprite planet/desert2
-		distance 520.9
+		distance 1852.17
 		period 215.561
 	object
 		sprite planet/water0-b
-		distance 709.11
+		distance 2607.22
 		period 342.38
 	object
 		sprite planet/lava4
-		distance 1220.35
+		distance 4764.05
 		period 772.974
 	object
 		sprite planet/gas0-b
-		distance 2094.35
+		distance 8689.23
 		period 1737.85
 		object
 			sprite planet/rock7-b
@@ -11124,8 +11124,8 @@ system Furmeliki
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1577
+	habitable 1717.88
+	belt 6335.9
 	link Dokdobaru
 	link Chikatip
 	link Kashikt
@@ -11147,15 +11147,15 @@ system Furmeliki
 		period 10
 	object
 		sprite planet/rock5-b
-		distance 133.64
+		distance 412.14
 		period 28.0119
 	object
 		sprite planet/lava6
-		distance 356.61
+		distance 1217.65
 		period 122.104
 	object "Elek Kartanu"
 		sprite planet/cloud4
-		distance 694.699
+		distance 2548.51
 		period 331.996
 		object
 			sprite planet/station2kd
@@ -11163,7 +11163,7 @@ system Furmeliki
 			period 27.0214
 	object
 		sprite planet/gas16
-		distance 1754.68
+		distance 7135.24
 		period 1332.71
 		object
 			sprite planet/oberon-b
@@ -11187,8 +11187,8 @@ system Gacrux
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 534.375
-	belt 1188
+	habitable 1905.33
+	belt 4623.89
 	link "Cor Caroli"
 	link Muhlifain
 	link Turais
@@ -11215,28 +11215,28 @@ system Gacrux
 	fleet "Small Republic" 15000
 	object
 		sprite star/k5
-		distance 32.6953
+		distance 87.86
 		period 12.7313
 	object
 		sprite star/m0
-		distance 48.8047
+		distance 136.25
 		period 12.7313
 		offset 180
 	object
 		sprite planet/lava5
-		distance 316.995
+		distance 1068.98
 		period 97.6596
 	object
 		sprite planet/ocean5
-		distance 698.285
+		distance 2563.11
 		period 319.29
 	object
 		sprite planet/mercury-b
-		distance 1053.44
+		distance 4045.71
 		period 591.636
 	object
 		sprite planet/gas5
-		distance 1920.69
+		distance 7890.71
 		period 1456.55
 		object
 			sprite planet/rock7-b
@@ -11256,8 +11256,8 @@ system "Gamma Cassiopeiae"
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 455.625
-	belt 1779
+	habitable 1596.92
+	belt 7245.41
 	haze _menu/haze-133
 	link Mirach
 	asteroids "small rock" 17 7.4936
@@ -11288,19 +11288,19 @@ system "Gamma Cassiopeiae"
 		period 10
 	object
 		sprite planet/ice7
-		distance 208.99
+		distance 674.73
 		period 56.6167
 	object
 		sprite planet/cloud2
-		distance 465
+		distance 1633.34
 		period 187.904
 	object
 		sprite planet/desert6-b
-		distance 789.64
+		distance 2937.69
 		period 415.815
 	object
 		sprite planet/gas3
-		distance 1622.89
+		distance 6541.39
 		period 1225.15
 		object
 			sprite planet/ganymede
@@ -11316,8 +11316,8 @@ system "Gamma Corvi"
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 1535.62
-	belt 1556
+	habitable 6151.2
+	belt 6242.09
 	haze _menu/haze-none
 	link Spica
 	asteroids "small rock" 20 1.5168
@@ -11346,20 +11346,20 @@ system "Gamma Corvi"
 	fleet "Human Miners" 5000
 	object
 		sprite star/g0
-		distance 39.0165
+		distance 106.61
 		period 15.3924
 		offset 180
 	object
 		sprite star/k0
-		distance 92.4835
+		distance 274.86
 		period 15.3924
 	object
 		sprite planet/rock8
-		distance 285.074
+		distance 950.66
 		period 49.1307
 	object
 		sprite planet/gas1
-		distance 757.074
+		distance 2803.56
 		period 212.63
 		object
 			sprite planet/ice0-b
@@ -11367,15 +11367,15 @@ system "Gamma Corvi"
 			period 14.9572
 	object Bourne
 		sprite planet/forest1-b
-		distance 1321.68
+		distance 5205.82
 		period 490.466
 	object
 		sprite planet/rhea-b
-		distance 1770.97
+		distance 7209.02
 		period 760.739
 	object
 		sprite planet/io
-		distance 3454.86
+		distance 15182.08
 		period 2072.83
 
 system Gerenus
@@ -11384,7 +11384,7 @@ system Gerenus
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 9065.92
+	habitable 44630.99
 	link Esix
 	link Nona
 	asteroids "large metal" 5 5
@@ -11415,23 +11415,23 @@ system Gerenus
 		period 8.42267
 	object
 		sprite planet/gas4-hot
-		distance 329.94
+		distance 1117.35
 		period 25.1772
 	object "Palarei"
 		sprite planet/rock10-b
-		distance 757.43
+		distance 2805.02
 		period 87.5725
 	object
 		sprite planet/mars
-		distance 1413.32
+		distance 5608.75
 		period 223.211
 	object
 		sprite planet/ice5-b
-		distance 1666.32
+		distance 6736.49
 		period 285.754
 	object
 		sprite planet/gas9
-		distance 2533.32
+		distance 10741.44
 		period 535.66
 		object
 			sprite planet/io
@@ -11443,8 +11443,8 @@ system Gienah
 	government Pirate
 	attributes "core"
 	arrival 1500
-	habitable 534.375
-	belt 1939
+	habitable 1905.33
+	belt 7974.52
 	link Persian
 	link Algenib
 	asteroids "small rock" 1 2.574
@@ -11471,16 +11471,16 @@ system Gienah
 	fleet "Large Syndicate" 5000
 	object
 		sprite star/k5-old
-		distance 31.893
+		distance 85.5
 		period 12.2656
 		offset 180
 	object
 		sprite star/m0
-		distance 47.607
+		distance 132.59
 		period 12.2656
 	object Covert
 		sprite planet/cloud4
-		distance 355.717
+		distance 1214.28
 		period 116.09
 		object
 			sprite planet/rock0
@@ -11488,11 +11488,11 @@ system Gienah
 			period 15.7161
 	object Mutiny
 		sprite planet/ice4
-		distance 814.357
+		distance 3039.91
 		period 402.123
 	object
 		sprite planet/desert5-b
-		distance 1189.57
+		distance 4630.68
 		period 709.938
 		object
 			sprite planet/dust7
@@ -11500,7 +11500,7 @@ system Gienah
 			period 17.6303
 	object
 		sprite planet/dust1-b
-		distance 2108.98
+		distance 8756.86
 		period 1675.89
 
 system Giribea
@@ -11509,7 +11509,7 @@ system Giribea
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 1705
+	habitable 6910.75
 	link Delia
 	link Feraticus
 	link Lire
@@ -11540,29 +11540,29 @@ system Giribea
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/g0-old
-		distance 46.9208
+		distance 130.49
 		period 14.0285
 		offset 180
 	object
 		sprite star/g5
-		distance 81.0792
+		distance 237.84
 		period 14.0285
 	object
 		sprite planet/lava0
-		distance 217.769
+		distance 706.08
 		period 31.131
 	object "Osaeli"
 		sprite planet/forest0-b
-		distance 562.609
+		distance 2017.19
 		period 129.273
 	object "Seli'het"
 		sprite planet/station1b
-		distance 950.019
+		distance 3607.02
 		period 283.659
 		object
 	object
 		sprite planet/gas9-b
-		distance 1952.66
+		distance 8037.1
 		period 835.868
 		object
 			sprite planet/dust4-b
@@ -11582,8 +11582,8 @@ system Girtab
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1080
-	belt 1387
+	habitable 4159.2
+	belt 5492.71
 	link Lesath
 	link Rastaban
 	link Albaldah
@@ -11612,15 +11612,15 @@ system Girtab
 		period 10
 	object
 		sprite planet/cloud4
-		distance 182.29
+		distance 580.28
 		period 29.9566
 	object
 		sprite planet/venus
-		distance 449.54
+		distance 1573.33
 		period 116.011
 	object Harmony
 		sprite planet/ocean1
-		distance 967.03
+		distance 3678.82
 		period 366.023
 		object
 			sprite planet/rock14-b
@@ -11628,7 +11628,7 @@ system Girtab
 			period 23.8681
 	object
 		sprite planet/gas15
-		distance 2147.19
+		distance 8933.77
 		period 1211.03
 		object
 			sprite planet/ice8-b
@@ -11648,8 +11648,8 @@ system Glubatub
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 233.28
-	belt 1093
+	habitable 761.8
+	belt 4214.86
 	link "Sol Arach"
 	link Miblulub
 	link Tebuteb
@@ -11683,7 +11683,7 @@ system Glubatub
 		period 10
 	object "Weir of Glubatub"
 		sprite planet/cloud0
-		distance 268.25
+		distance 888.86
 		period 115.062
 		object
 			sprite planet/desert4-b
@@ -11691,11 +11691,11 @@ system Glubatub
 			period 19.7613
 	object
 		sprite planet/desert6
-		distance 584.81
+		distance 2105.59
 		period 370.377
 	object
 		sprite planet/jupiter-b
-		distance 1332.37
+		distance 5252.66
 		period 1273.67
 		object
 			sprite planet/tethys-b
@@ -11703,7 +11703,7 @@ system Glubatub
 			period 12.1245
 	object
 		sprite planet/gas15
-		distance 2435.86
+		distance 10281.89
 		period 3148.47
 		object
 			sprite planet/dust4
@@ -11727,8 +11727,8 @@ system Gomeisa
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 911.25
-	belt 1616
+	habitable 3443.95
+	belt 6510.49
 	link Zosma
 	link "Epsilon Leonis"
 	link Adhara
@@ -11757,20 +11757,20 @@ system Gomeisa
 	fleet "Republic Logistics" 5000
 	object
 		sprite star/k0
-		distance 55.5
+		distance 156.88
 		period 15.4962
 		offset 180
 	object
 		sprite star/k0
-		distance 55.5
+		distance 156.88
 		period 15.4962
 	object
 		sprite planet/gas5-hot
-		distance 258.76
+		distance 854.19
 		period 55.1553
 	object Nifel
 		sprite planet/ocean6
-		distance 755.77
+		distance 2798.2
 		period 275.312
 		object
 			sprite planet/rock14
@@ -11778,11 +11778,11 @@ system Gomeisa
 			period 20.6644
 	object
 		sprite planet/cloud0-b
-		distance 1329.66
+		distance 5240.78
 		period 642.469
 	object
 		sprite planet/gas7-b
-		distance 2090.3
+		distance 8670.51
 		period 1266.35
 		object
 			sprite planet/rock0
@@ -11798,8 +11798,8 @@ system "Good Omen"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1715
-	belt 1598
+	habitable 6955.87
+	belt 6429.85
 	haze _menu/haze-67
 	link Beginning
 	asteroids "small rock" 1 2.5536
@@ -11829,23 +11829,23 @@ system "Good Omen"
 		period 10
 	object
 		sprite planet/titan-b
-		distance 161.09
+		distance 506.34
 		period 19.7483
 	object
 		sprite planet/lava6-b
-		distance 386.7
+		distance 1331.81
 		period 73.4496
 	object
 		sprite planet/desert9-b
-		distance 559.91
+		distance 2006.47
 		period 127.969
 	object
 		sprite planet/desert0-b
-		distance 1307.87
+		distance 5145.38
 		period 456.851
 	object "Shifting Sand"
 		sprite planet/ice1
-		distance 1682.91
+		distance 6811.17
 		period 666.836
 		object
 			sprite planet/lava0
@@ -11853,7 +11853,7 @@ system "Good Omen"
 			period 19.7858
 	object
 		sprite planet/gas10-b
-		distance 3837.15
+		distance 17068.68
 		period 2295.84
 
 system Gorvi
@@ -11861,8 +11861,8 @@ system Gorvi
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 670
-	belt 1345
+	habitable 2448.22
+	belt 5308.06
 	haze _menu/haze-133
 	link Tortor
 	link Mintaka
@@ -11892,19 +11892,19 @@ system Gorvi
 		period 100
 	object
 		sprite planet/lava0
-		distance 342.184
+		distance 1163.29
 		period 97.8164
 	object
 		sprite planet/lava7
-		distance 580.224
+		distance 2087.3
 		period 215.981
 	object
 		sprite planet/titan-b
-		distance 1076.43
+		distance 4143.92
 		period 545.762
 	object
 		sprite planet/gas16
-		distance 2298.59
+		distance 9638.33
 		period 1703.01
 		object
 			sprite planet/rock17
@@ -11920,8 +11920,8 @@ system Graffias
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 911.25
-	belt 1977
+	habitable 3443.95
+	belt 8148.74
 	link Alniyat
 	asteroids "small rock" 15 3.069
 	asteroids "medium rock" 45 1.749
@@ -11948,24 +11948,24 @@ system Graffias
 	fleet "Human Miners" 2000
 	object
 		sprite star/k0
-		distance 59.5
+		distance 169.32
 		period 17.2013
 		offset 180
 	object
 		sprite star/k0
-		distance 59.5
+		distance 169.32
 		period 17.2013
 	object
 		sprite planet/desert3-b
-		distance 308
+		distance 1035.5
 		period 71.6254
 	object Poisonwood
 		sprite planet/cloud8
-		distance 609.25
+		distance 2203.35
 		period 199.267
 	object
 		sprite planet/gas8
-		distance 1489.5
+		distance 5946.03
 		period 761.732
 		object
 			sprite planet/rock3-b
@@ -11985,8 +11985,8 @@ system Gupta
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 912.6
-	belt 1771
+	habitable 3449.61
+	belt 7209.15
 	link Ablodab
 	link Belugt
 	link Blugtad
@@ -12018,28 +12018,28 @@ system Gupta
 	fleet Heliarch 800
 	object
 		sprite star/k0
-		distance 46.2043
+		distance 128.31
 		period 13.0429
 		offset 180
 	object
 		sprite star/k5
-		distance 52.7957
+		distance 148.51
 		period 13.0429
 	object
 		sprite planet/lava2-b
-		distance 181.046
+		distance 575.92
 		period 32.2554
 	object
 		sprite planet/rock13-b
-		distance 566.296
+		distance 2031.84
 		period 178.437
 	object "Market of Gupta"
 		sprite planet/forest6
-		distance 916.031
+		distance 3464.02
 		period 367.101
 	object
 		sprite planet/gas9-b
-		distance 1879.03
+		distance 7700.38
 		period 1078.5
 
 system Hadar
@@ -12047,8 +12047,8 @@ system Hadar
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 455.625
-	belt 1520
+	habitable 1596.92
+	belt 6081.63
 	link "Zeta Centauri"
 	link Izar
 	link Zubeneschamali
@@ -12080,11 +12080,11 @@ system Hadar
 		period 10
 	object
 		sprite planet/oberon-b
-		distance 107.34
+		distance 323.8
 		period 20.84
 	object Skymoot
 		sprite planet/cloud6
-		distance 461.83
+		distance 1621.02
 		period 185.986
 		object
 			sprite planet/rock14-b
@@ -12092,11 +12092,11 @@ system Hadar
 			period 20.6379
 	object
 		sprite planet/rock18
-		distance 1282.92
+		distance 5036.36
 		period 861.104
 	object
 		sprite planet/uranus-b
-		distance 2293.68
+		distance 9615.39
 		period 2058.52
 		object "Typhon Station"
 			sprite planet/station4
@@ -12108,8 +12108,8 @@ system Hamal
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1080
-	belt 1241
+	habitable 4159.2
+	belt 4853.75
 	haze _menu/haze-133
 	link Ruchbah
 	asteroids "small rock" 3 2.7552
@@ -12140,23 +12140,23 @@ system Hamal
 		period 10
 	object
 		sprite planet/callisto-b
-		distance 160.25
+		distance 503.43
 		period 24.6914
 	object
 		sprite planet/lava1
-		distance 423.06
+		distance 1471.06
 		period 105.913
 	object
 		sprite planet/lava2
-		distance 879.15
+		distance 3309.52
 		period 317.28
 	object Trove
 		sprite planet/dust0
-		distance 1269.04
+		distance 4975.82
 		period 550.251
 	object
 		sprite planet/gas6
-		distance 2570.04
+		distance 10915.13
 		period 1585.83
 
 system Han
@@ -12164,8 +12164,8 @@ system Han
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1080.62
-	belt 1517
+	habitable 4161.85
+	belt 6068.28
 	link Alniyat
 	link Atria
 	asteroids "large metal" 1 2.85
@@ -12187,24 +12187,24 @@ system Han
 	fleet "Large Militia" 10000
 	object
 		sprite star/g5
-		distance 47.4335
+		distance 132.06
 		period 14.5195
 		offset 180
 	object
 		sprite star/k0
-		distance 65.0665
+		distance 186.79
 		period 14.5195
 	object
 		sprite planet/ice1-b
-		distance 370.007
+		distance 1268.35
 		period 86.6037
 	object
 		sprite planet/ocean6
-		distance 677.097
+		distance 2477.0
 		period 214.387
 	object Darkstone
 		sprite planet/ice3
-		distance 1116.66
+		distance 4316.36
 		period 454.048
 		object
 			sprite planet/ice7
@@ -12212,11 +12212,11 @@ system Han
 			period 18.0139
 	object
 		sprite planet/rock17
-		distance 1526.15
+		distance 6109.01
 		period 725.466
 	object
 		sprite planet/dust1-b
-		distance 3667.91
+		distance 16230.57
 		period 2703.02
 
 system Hassaleh
@@ -12224,8 +12224,8 @@ system Hassaleh
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 670
-	belt 1924
+	habitable 2448.22
+	belt 7905.85
 	haze _menu/haze-67
 	link Rigel
 	link Sumar
@@ -12257,28 +12257,28 @@ system Hassaleh
 	fleet "Human Miners" 2000
 	object
 		sprite star/k0
-		distance 36.1558
+		distance 98.09
 		period 18.5627
 	object
 		sprite star/m0
-		distance 76.8442
+		distance 224.23
 		period 18.5627
 		offset 180
 	object
 		sprite planet/desert8-b
-		distance 278.344
+		distance 925.89
 		period 71.7622
 	object
 		sprite planet/desert9
-		distance 640.234
+		distance 2327.91
 		period 250.34
 	object
 		sprite planet/dust5
-		distance 1164.64
+		distance 4522.95
 		period 614.204
 	object
 		sprite planet/rhea-b
-		distance 2183.89
+		distance 9104.04
 		period 1577.14
 
 system Hatysa
@@ -12286,8 +12286,8 @@ system Hatysa
 	government Pirate
 	attributes "north"
 	arrival 1500
-	habitable 533.75
-	belt 1163
+	habitable 1902.86
+	belt 4515.87
 	haze _menu/haze-33
 	link Arneb
 	link Alnilam
@@ -12315,16 +12315,16 @@ system Hatysa
 	fleet "Large Republic" 15000
 	object
 		sprite star/k0
-		distance 13.6124
+		distance 33.75
 		period 15.528
 	object
 		sprite star/m8
-		distance 79.3876
+		distance 232.4
 		period 15.528
 		offset 180
 	object
 		sprite planet/rock2
-		distance 420.978
+		distance 1463.05
 		period 149.548
 		object
 			sprite planet/dust2
@@ -12332,23 +12332,23 @@ system Hatysa
 			period 21.949
 	object
 		sprite planet/ocean4
-		distance 897.418
+		distance 3385.95
 		period 465.461
 	object
 		sprite planet/gas11-b
-		distance 1294.67
+		distance 5087.67
 		period 806.545
 	object
 		sprite planet/io-b
-		distance 2814.92
+		distance 12080.78
 		period 2585.77
 
 system "Heia Due"
 	pos -146.177 -481.694
 	government Hai
 	arrival 1500
-	habitable 1215
-	belt 1079
+	habitable 4740.84
+	belt 4154.92
 	haze _menu/haze-67
 	link Waypoint
 	link "Due Yoot"
@@ -12379,28 +12379,28 @@ system "Heia Due"
 	fleet "Hai Surveillance" 2000
 	object
 		sprite star/g0
-		distance 13.2222
+		distance 32.7
 		period 14.8968
 		offset 180
 	object
 		sprite star/m8
-		distance 105.778
+		distance 318.62
 		period 14.8968
 	object
 		sprite planet/titan
-		distance 279.538
+		distance 930.28
 		period 53.6331
 	object
 		sprite planet/desert3
-		distance 637.538
+		distance 2317.05
 		period 184.727
 	object Allhome
 		sprite planet/forest1
-		distance 1294.54
+		distance 5087.1
 		period 534.495
 	object
 		sprite planet/gas16
-		distance 1912.1
+		distance 7851.43
 		period 959.482
 		object
 			sprite planet/dust3-b
@@ -12420,8 +12420,8 @@ system Hesselpost
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1327
+	habitable 1717.88
+	belt 5229.13
 	haze _menu/haze-133
 	link Dokdobaru
 	asteroids "small rock" 34 1.4872
@@ -12448,19 +12448,19 @@ system Hesselpost
 		period 10
 	object
 		sprite planet/venus-b
-		distance 202
+		distance 649.87
 		period 52.0553
 	object "Sarisa Fentra"
 		sprite planet/cloud0
-		distance 409.44
+		distance 1418.74
 		period 150.219
 	object
 		sprite planet/rock17-b
-		distance 659.48
+		distance 2405.63
 		period 307.072
 	object
 		sprite planet/lava4
-		distance 1118.12
+		distance 4322.63
 		period 677.905
 		object
 			sprite planet/station3kd
@@ -12468,7 +12468,7 @@ system Hesselpost
 			period 25.4596
 	object
 		sprite planet/gas2-b
-		distance 2053.35
+		distance 8499.98
 		period 1687.07
 		object
 			sprite planet/rock3
@@ -12492,8 +12492,8 @@ system "Hevru Hai"
 	government Quarg
 	attributes "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1245
+	habitable 2570.09
+	belt 4871.14
 	link "Fah Soom"
 	trade Clothing 362
 	trade Electronics 763
@@ -12515,91 +12515,91 @@ system "Hevru Hai"
 		period 10
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 20
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 40
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 60
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 80
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 100
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 120
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 140
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 160
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 220
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 240
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 260
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 280
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 300
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 320
 	object "Alta Hai"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 340
 
@@ -12607,8 +12607,8 @@ system "Hi Yahr"
 	pos 82.3672 -641.6
 	government "Hai (Unfettered)"
 	arrival 1500
-	habitable 625
-	belt 1655
+	habitable 2266.58
+	belt 6685.58
 	link "Wah Yoot"
 	asteroids "small rock" 18 5.9136
 	asteroids "medium rock" 65 5.4656
@@ -12635,25 +12635,25 @@ system "Hi Yahr"
 		period 10
 	object
 		sprite planet/rock19
-		distance 219.25
+		distance 711.38
 		period 51.9433
 	object
 		sprite planet/mercury-b
-		distance 420.26
+		distance 1460.29
 		period 137.847
 	object Warfeed
 		sprite planet/ocean2
-		distance 625.02
+		distance 2266.66
 		period 250.012
 		offset 47.6623
 	object
 		sprite planet/gas15-b
-		distance 1187.26
+		distance 4620.69
 		period 654.544
 		offset 19.1907
 	object
 		sprite planet/rock18-b
-		distance 1939.51
+		distance 7976.85
 		period 1366.65
 		offset 5.57518
 		object
@@ -12666,8 +12666,8 @@ system Hintar
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 625
-	belt 1725
+	habitable 2266.58
+	belt 7001.03
 	haze _menu/haze-133
 	link Cebalrai
 	asteroids "small rock" 34 2.016
@@ -12695,11 +12695,11 @@ system Hintar
 		period 10
 	object
 		sprite planet/desert1-b
-		distance 208.64
+		distance 673.48
 		period 48.2188
 	object
 		sprite planet/gas15-b
-		distance 1096.89
+		distance 4231.53
 		period 581.252
 		object
 			sprite planet/ice8
@@ -12719,7 +12719,7 @@ system Hintar
 			period 80.3672
 	object
 		sprite planet/neptune-b
-		distance 2054.14
+		distance 8503.62
 		period 1489.58
 
 system Holeb
@@ -12727,8 +12727,8 @@ system Holeb
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1715
-	belt 1181
+	habitable 6955.87
+	belt 4593.62
 	link Alioth
 	link Rutilicus
 	link Arcturus
@@ -12752,23 +12752,23 @@ system Holeb
 		period 10
 	object
 		sprite planet/lava4-b
-		distance 193.09
+		distance 618.32
 		period 25.916
 	object
 		sprite planet/desert6
-		distance 617.65
+		distance 2237.05
 		period 148.266
 	object
 		sprite planet/dust1-b
-		distance 882.29
+		distance 3322.65
 		period 253.131
 	object
 		sprite planet/rock14
-		distance 1394.93
+		distance 5527.64
 		period 503.218
 	object
 		sprite planet/jupiter
-		distance 3958.09
+		distance 17670.33
 		period 2405.23
 
 system Homeward
@@ -12776,8 +12776,8 @@ system Homeward
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 425.92
-	belt 1499
+	habitable 1482.07
+	belt 5988.23
 	link "Silver Bell"
 	link Quaru
 	asteroids "small rock" 20 6.1248
@@ -12811,23 +12811,23 @@ system Homeward
 		period 10
 	object
 		sprite planet/desert2-b
-		distance 218.61
+		distance 709.09
 		period 62.6471
 	object "Far Home"
 		sprite planet/forest3-b
-		distance 420.7
+		distance 1461.98
 		period 167.246
 	object
 		sprite planet/desert4
-		distance 814.95
+		distance 3042.36
 		period 450.913
 	object
 		sprite planet/desert3-b
-		distance 1289.2
+		distance 5063.78
 		period 897.173
 	object
 		sprite planet/gas7-b
-		distance 2236.41
+		distance 9348.29
 		period 2049.85
 		object
 			sprite planet/rock7
@@ -12842,8 +12842,8 @@ system Host
 	pos 384.431 -543.812
 	government Uninhabited
 	arrival 1500
-	habitable 486.68
-	belt 1669
+	habitable 1717.88
+	belt 6748.54
 	asteroids "large metal" 1 0.732
 	trade Clothing 268
 	trade Electronics 639
@@ -12860,11 +12860,11 @@ system Host
 		period 10
 	object
 		sprite planet/cloud8
-		distance 157.84
+		distance 495.09
 		period 35.9554
 	object Avalon
 		sprite planet/forest0
-		distance 478.33
+		distance 1685.27
 		period 189.684
 		object
 			sprite planet/dust0
@@ -12872,11 +12872,11 @@ system Host
 			period 15.2326
 	object
 		sprite planet/rock16
-		distance 1139.14
+		distance 4413.03
 		period 697.114
 	object
 		sprite planet/gas2-b
-		distance 1885.15
+		distance 7728.31
 		period 1484.08
 		object
 			sprite planet/ice7-b
@@ -12892,8 +12892,8 @@ system Hunter
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 425.92
-	belt 1498
+	habitable 1482.07
+	belt 5983.79
 	link "Bright Void"
 	link "Dark Hills"
 	link "Broken Bowl"
@@ -12927,19 +12927,19 @@ system Hunter
 		period 10
 	object
 		sprite planet/cloud6
-		distance 256.01
+		distance 844.17
 		period 79.3928
 	object "Shadow of Leaves"
 		sprite planet/forest2-b
-		distance 485.62
+		distance 1713.74
 		period 207.415
 	object
 		sprite planet/rock11-b
-		distance 689.03
+		distance 2525.46
 		period 350.553
 	object
 		sprite planet/gas12-b
-		distance 2352.59
+		distance 9890.97
 		period 2211.64
 		object
 			sprite planet/dust3-b
@@ -12954,8 +12954,8 @@ system Ik'kara'ka
 	pos 56.2159 -888.296
 	government Wanderer
 	arrival 1500
-	habitable 625
-	belt 1497
+	habitable 2266.58
+	belt 5979.34
 	haze _menu/haze-none
 	link Chy'chra
 	link Prakacha'a
@@ -12985,15 +12985,15 @@ system Ik'kara'ka
 		period 10
 	object
 		sprite planet/lava2
-		distance 147.09
+		distance 458.06
 		period 28.5427
 	object
 		sprite planet/rock8
-		distance 351.78
+		distance 1199.42
 		period 105.567
 	object "Varu Mer'ek"
 		sprite planet/desert2
-		distance 871.99
+		distance 3279.61
 		period 411.991
 		object
 			sprite planet/rock14
@@ -13001,7 +13001,7 @@ system Ik'kara'ka
 			period 23.9546
 	object
 		sprite planet/gas4
-		distance 2659.95
+		distance 11341.64
 		period 2194.98
 		object
 			sprite planet/io
@@ -13017,8 +13017,8 @@ system Ildaria
 	government Republic
 	attributes "rim" "wolf-rayet"
 	arrival 1500
-	habitable 625
-	belt 1132
+	habitable 2266.58
+	belt 4382.3
 	haze _menu/haze-133
 	link Zubeneschamali
 	link Kochab
@@ -13048,7 +13048,7 @@ system Ildaria
 		period 10
 	object
 		sprite planet/ice4-b
-		distance 694.26
+		distance 2546.73
 		period 292.687
 		object
 			sprite planet/ice8
@@ -13056,23 +13056,23 @@ system Ildaria
 			period 16.9135
 	object
 		sprite planet/rock6-b
-		distance 1135.47
+		distance 4397.23
 		period 612.186
 	object
 		sprite planet/rock17-b
-		distance 1893.08
+		distance 7764.52
 		period 1317.87
 	object
 		sprite planet/dust4-b
-		distance 2712.92
+		distance 11593.73
 		period 2260.87
 
 system "Imo Dep"
 	pos -56.2764 -600.1
 	government Hai
 	arrival 1500
-	habitable 1715
-	belt 1416
+	habitable 6955.87
+	belt 5620.58
 	haze _menu/haze-67
 	link "Zuba Zub"
 	asteroids "small rock" 11 2.66
@@ -13104,7 +13104,7 @@ system "Imo Dep"
 		period 10
 	object
 		sprite planet/gas10-hot
-		distance 571.36
+		distance 2051.99
 		period 131.915
 		object
 			sprite planet/ice8-b
@@ -13116,15 +13116,15 @@ system "Imo Dep"
 			period 27.2812
 	object
 		sprite planet/rock19
-		distance 1157.36
+		distance 4491.54
 		period 380.304
 	object Stonebreak
 		sprite planet/forest4
-		distance 1708.25
+		distance 6925.41
 		period 681.954
 	object
 		sprite planet/gas10-b
-		distance 2475.25
+		distance 10467.37
 		period 1189.48
 		object
 			sprite planet/ice0-b
@@ -13144,8 +13144,8 @@ system Insitor
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 553.28
-	belt 1170
+	habitable 1980.16
+	belt 4546.09
 	haze _menu/haze-red
 	link Antevorta
 	asteroids "small rock" 1 2.54427
@@ -13163,28 +13163,28 @@ system Insitor
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/m0
-		distance 43.8496
+		distance 121.16
 		period 18.0359
 		offset 180
 	object
 		sprite star/m4
-		distance 60.1504
+		distance 171.36
 		period 18.0359
 	object
 		sprite planet/gas1-hot
-		distance 247.76
+		distance 814.18
 		period 66.3186
 	object
 		sprite planet/rock12
-		distance 511.01
+		distance 1813.26
 		period 196.441
 	object
 		sprite planet/ice2
-		distance 735.45
+		distance 2714.86
 		period 339.17
 	object
 		sprite planet/mars
-		distance 1745.14
+		distance 7092.07
 		period 1239.75
 		object
 			sprite planet/dust4-b
@@ -13192,15 +13192,15 @@ system Insitor
 			period 24.7983
 	object "Ember Wormhole"
 		sprite planet/wormhole-red
-		distance 4713.14
+		distance 21474.41
 		period 5502.41
 
 system "Io Lowe"
 	pos -94.7566 -527.728
 	government Hai
 	arrival 1500
-	habitable 135
-	belt 1552
+	habitable 416.76
+	belt 6224.24
 	haze _menu/haze-67
 	link "Heia Due"
 	link "Mei Yohn"
@@ -13234,15 +13234,15 @@ system "Io Lowe"
 		period 10
 	object Heartvalley
 		sprite planet/rock16
-		distance 138.56
+		distance 428.88
 		period 56.15
 	object
 		sprite planet/gas11-b
-		distance 500.32
+		distance 1771.29
 		period 385.27
 	object
 		sprite planet/uranus-b
-		distance 1441.33
+		distance 5732.52
 		period 1883.81
 		object
 			sprite planet/desert4-b
@@ -13261,8 +13261,8 @@ system "Io Mann"
 	pos -192.955 -447.669
 	government Hai
 	arrival 1500
-	habitable 973.36
-	belt 1132
+	habitable 3705.57
+	belt 4382.3
 	haze _menu/haze-67
 	link "Wah Oh"
 	link "Due Yoot"
@@ -13291,16 +13291,16 @@ system "Io Mann"
 	fleet "Hai Surveillance" 3000
 	object
 		sprite star/k0
-		distance 54
+		distance 152.23
 		period 14.3899
 		offset 180
 	object
 		sprite star/k0
-		distance 54
+		distance 152.23
 		period 14.3899
 	object
 		sprite planet/gas10
-		distance 452.21
+		distance 1583.68
 		period 123.292
 		object
 			sprite planet/ice8
@@ -13312,7 +13312,7 @@ system "Io Mann"
 			period 22.0677
 	object
 		sprite planet/gas2
-		distance 1068.21
+		distance 4108.78
 		period 447.619
 		object Skyfarm
 			sprite planet/ice7
@@ -13320,7 +13320,7 @@ system "Io Mann"
 			period 14.8772
 	object
 		sprite planet/gas6-b
-		distance 2046.3
+		distance 8467.48
 		period 1186.8
 		offset 360
 		object
@@ -13337,8 +13337,8 @@ system Ipsing
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1400
-	belt 1107
+	habitable 5549.99
+	belt 4274.89
 	haze _menu/haze-67
 	link Mizar
 	asteroids "large metal" 1 1.1424
@@ -13356,20 +13356,20 @@ system Ipsing
 	fleet "Small Southern Pirates" 3000
 	object
 		sprite star/g0-old
-		distance 21.7143
+		distance 56.17
 		period 9.89877
 		offset 180
 	object
 		sprite star/k5
-		distance 73.2857
+		distance 212.85
 		period 9.89877
 	object
 		sprite planet/rock11
-		distance 276.326
+		distance 918.47
 		period 49.1052
 	object
 		sprite planet/rock18-b
-		distance 756.086
+		distance 2799.5
 		period 222.256
 		object
 			sprite planet/io
@@ -13377,11 +13377,11 @@ system Ipsing
 			period 20.1302
 	object
 		sprite planet/cloud4
-		distance 1178.25
+		distance 4581.73
 		period 432.364
 	object
 		sprite planet/gas12-b
-		distance 2674.01
+		distance 11408.5
 		period 1478.22
 		object
 			sprite planet/rock14-b
@@ -13404,8 +13404,8 @@ system Iyech'yek
 	pos -277.37 -693.913
 	government Wanderer
 	arrival 1500
-	habitable 320
-	belt 1613
+	habitable 1080.19
+	belt 6497.04
 	haze _menu/haze-33
 	link Ek'kek'ru
 	link Kiru'kichi
@@ -13435,15 +13435,15 @@ system Iyech'yek
 		period 10
 	object "Tik Klai"
 		sprite planet/rock15
-		distance 146.25
+		distance 455.18
 		period 39.5484
 	object "Vara Kehi'ki"
 		sprite planet/ice1
-		distance 359.49
+		distance 1228.53
 		period 152.411
 	object
 		sprite planet/gas10-b
-		distance 875.85
+		distance 3295.73
 		period 579.602
 		object
 			sprite planet/rock3-b
@@ -13451,7 +13451,7 @@ system Iyech'yek
 			period 17.1764
 	object
 		sprite planet/neptune-b
-		distance 2050.85
+		distance 8488.45
 		period 2076.76
 
 system Izar
@@ -13459,8 +13459,8 @@ system Izar
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 1294.38
-	belt 1449
+	habitable 5086.4
+	belt 5766.46
 	haze _menu/haze-67
 	link Acrux
 	link Hadar
@@ -13488,24 +13488,24 @@ system Izar
 	fleet "Large Militia" 1200
 	object
 		sprite star/g0
-		distance 15.6511
+		distance 39.3
 		period 10.2136
 		offset 180
 	object
 		sprite star/m0
-		distance 78.8489
+		distance 230.66
 		period 10.2136
 	object
 		sprite planet/ice7
-		distance 249.959
+		distance 822.16
 		period 43.9372
 	object
 		sprite planet/rhea
-		distance 430.849
+		distance 1501.07
 		period 99.43
 	object Poseidos
 		sprite planet/ocean2
-		distance 849.139
+		distance 3184.35
 		period 275.105
 		object
 			sprite planet/io
@@ -13513,7 +13513,7 @@ system Izar
 			period 16.8355
 	object
 		sprite planet/neptune
-		distance 2239.39
+		distance 9362.16
 		period 1178.21
 		object "Wyvern Station"
 			sprite planet/station8
@@ -13524,8 +13524,8 @@ system Ka'ch'chrai
 	pos -240.163 -822.448
 	government Wanderer
 	arrival 1500
-	habitable 425.92
-	belt 1745
+	habitable 1482.07
+	belt 7091.44
 	haze _menu/haze-none
 	link Ap'arak
 	link Ek'kek'ru
@@ -13555,19 +13555,19 @@ system Ka'ch'chrai
 		period 10
 	object
 		sprite planet/europa
-		distance 191.36
+		distance 612.21
 		period 51.3065
 	object "Vara K'chrai"
 		sprite planet/earth
-		distance 458.36
+		distance 1607.54
 		period 190.198
 	object
 		sprite planet/ocean5-b
-		distance 718.97
+		distance 2647.46
 		period 373.648
 	object
 		sprite planet/ice5-b
-		distance 1280.61
+		distance 5026.28
 		period 888.222
 		object
 			sprite planet/rock7-b
@@ -13575,15 +13575,15 @@ system Ka'ch'chrai
 			period 18.7183
 	object
 		sprite planet/gas13
-		distance 3482.61
+		distance 15318.22
 		period 3983.39
 
 system Ka'pru
 	pos -76.6756 -994.955
 	government Wanderer
 	arrival 1500
-	habitable 1505.92
-	belt 1808
+	habitable 6018.99
+	belt 7377.01
 	haze _menu/haze-33
 	link Kiro'ku
 	asteroids "medium rock" 2 2.7573
@@ -13609,32 +13609,32 @@ system Ka'pru
 	fleet "Wanderer Defense" 5000
 	object
 		sprite star/g0
-		distance 29.4144
+		distance 78.26
 		period 10.9322
 	object
 		sprite star/k5
-		distance 74.5856
+		distance 217.0
 		period 10.9322
 		offset 180
 	object
 		sprite planet/gas6-hot
-		distance 261.426
+		distance 863.92
 		period 43.5694
 	object
 		sprite planet/desert0
-		distance 510.986
+		distance 1813.16
 		period 119.062
 	object
 		sprite planet/lava1
-		distance 785.026
+		distance 2918.64
 		period 226.717
 	object "Vara Ke'stai"
 		sprite planet/forest0
-		distance 1178.24
+		distance 4581.69
 		period 416.876
 	object
 		sprite planet/gas11
-		distance 2026.49
+		distance 8376.23
 		period 940.317
 		object
 			sprite planet/dust4
@@ -13654,8 +13654,8 @@ system Kaliptari
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1089
+	habitable 1080.19
+	belt 4197.72
 	link Skeruto
 	link Fornarep
 	link Mekislepti
@@ -13686,7 +13686,7 @@ system Kaliptari
 		period 10
 	object "Spera Anatrusk"
 		sprite planet/mars
-		distance 316.61
+		distance 1067.55
 		period 125.971
 		object
 			sprite planet/io-b
@@ -13694,11 +13694,11 @@ system Kaliptari
 			period 23.335
 	object
 		sprite planet/dust2
-		distance 602.61
+		distance 2176.74
 		period 330.78
 	object
 		sprite planet/uranus-b
-		distance 1207.17
+		distance 4706.89
 		period 937.859
 		object
 			sprite planet/callisto
@@ -13714,7 +13714,7 @@ system Kaliptari
 			period 42.7022
 	object
 		sprite planet/gas10
-		distance 3109.42
+		distance 13498.6
 		period 3877.07
 		object
 			sprite planet/lava0-b
@@ -13730,8 +13730,8 @@ system "Kappa Centauri"
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1215
-	belt 1508
+	habitable 4740.84
+	belt 6028.24
 	link Pherkad
 	link "Beta Lupi"
 	asteroids "large metal" 1 3.9349
@@ -13751,32 +13751,32 @@ system "Kappa Centauri"
 	fleet "Small Militia" 2000
 	object
 		sprite star/g0
-		distance 10.2222
+		distance 24.71
 		period 10.1264
 	object
 		sprite star/m4
-		distance 81.7778
+		distance 240.1
 		period 10.1264
 		offset 180
 	object
 		sprite planet/mercury-b
-		distance 311.068
+		distance 1046.91
 		period 62.9585
 	object
 		sprite planet/lava3-b
-		distance 652.678
+		distance 2378.13
 		period 191.346
 	object Cornucopia
 		sprite planet/forest3
-		distance 1198.68
+		distance 4670.11
 		period 476.24
 	object
 		sprite planet/tethys-b
-		distance 1542.24
+		distance 6180.71
 		period 695.022
 	object
 		sprite planet/gas17-b
-		distance 2905.68
+		distance 12515.94
 		period 1797.39
 		object
 			sprite planet/ganymede
@@ -13792,8 +13792,8 @@ system Kashikt
 	government "Kor Efret"
 	attributes "korath"
 	arrival 1500
-	habitable 1715
-	belt 1013
+	habitable 6955.87
+	belt 3873.56
 	link Dokdobaru
 	link Furmeliki
 	link Sumprast
@@ -13825,7 +13825,7 @@ system Kashikt
 		period 10
 	object
 		sprite planet/rock1
-		distance 266.49
+		distance 882.42
 		period 42.0193
 		object
 			sprite planet/desert4
@@ -13833,11 +13833,11 @@ system Kashikt
 			period 17.2357
 	object
 		sprite planet/cloud4-b
-		distance 693.7
+		distance 2544.45
 		period 176.476
 	object "Laki Nemparu"
 		sprite planet/venus
-		distance 1319.31
+		distance 5195.44
 		period 462.858
 		object "Tefkar Ret"
 			sprite planet/station2k
@@ -13845,11 +13845,11 @@ system Kashikt
 			period 16.3315
 	object
 		sprite planet/gas2
-		distance 1983.2
+		distance 8177.2
 		period 853.056
 	object
 		sprite planet/gas6
-		distance 2650.49
+		distance 11296.69
 		period 1318.01
 		object
 			sprite planet/ice7-b
@@ -13861,8 +13861,8 @@ system Kasikfar
 	government Uninhabited
 	attributes "archon" "korath" "nova"
 	arrival 1500
-	habitable 100
-	belt 1539
+	habitable 299.53
+	belt 6166.27
 	haze _menu/haze-blackbody
 	asteroids "small rock" 4 3.8019
 	asteroids "medium rock" 3 4.4689
@@ -13887,15 +13887,15 @@ system Kasikfar
 		period 1000
 	object
 		sprite planet/rock13-b
-		distance 947.181
+		distance 3595.06
 		period 528.552
 	object
 		sprite planet/miranda
-		distance 1115.2
+		distance 4310.09
 		period 675.257
 	object
 		sprite planet/callisto
-		distance 1339.26
+		distance 5282.88
 		period 888.661
 
 system "Kaus Australis"
@@ -13903,8 +13903,8 @@ system "Kaus Australis"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1281
+	habitable 1080.19
+	belt 5027.98
 	haze _menu/haze-133
 	link Dabih
 	link Tais
@@ -13936,19 +13936,19 @@ system "Kaus Australis"
 		period 10
 	object Hopper
 		sprite planet/cloud8
-		distance 234.64
+		distance 766.7
 		period 80.3689
 	object
 		sprite planet/callisto-b
-		distance 513.6
+		distance 1823.44
 		period 260.269
 	object
 		sprite planet/rock10-b
-		distance 1076.44
+		distance 4143.97
 		period 789.714
 	object
 		sprite planet/gas5-b
-		distance 2530.4
+		distance 10727.64
 		period 2846.22
 
 system "Kaus Borealis"
@@ -13956,8 +13956,8 @@ system "Kaus Borealis"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 590.625
-	belt 1074
+	habitable 2128.81
+	belt 4133.53
 	haze _menu/haze-133
 	link Cebalrai
 	link "Alpha Arae"
@@ -13983,28 +13983,28 @@ system "Kaus Borealis"
 	fleet "Small Southern Pirates" 5000
 	object
 		sprite star/k0
-		distance 20.4571
+		distance 52.63
 		period 13.936
 	object
 		sprite star/m4
-		distance 69.0429
+		distance 199.36
 		period 13.936
 		offset 180
 	object
 		sprite planet/rock11-b
-		distance 252.453
+		distance 831.23
 		period 66.0198
 	object "New Iceland"
 		sprite planet/ocean7
-		distance 557.093
+		distance 1995.28
 		period 216.419
 	object
 		sprite planet/rock0-b
-		distance 1059.78
+		distance 4072.77
 		period 567.844
 	object
 		sprite planet/gas10
-		distance 1868.34
+		distance 7651.62
 		period 1329.2
 		object
 			sprite planet/dust4
@@ -14020,8 +14020,8 @@ system "Ki War Ek"
 	government Heliarch
 	attributes "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1777
+	habitable 2570.09
+	belt 7236.35
 	haze _menu/haze-133
 	link Quaru
 	link Ekuarik
@@ -14057,181 +14057,181 @@ system "Ki War Ek"
 		period 10
 	object
 		sprite planet/lava4-b
-		distance 812
+		distance 3030.14
 		period 360
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 65
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 85
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 100
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 120
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 140
 	object "Ring of Power"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 160
 	object "Ring of Power"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object "Ring of Power"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object "Ring of Power"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 220
 	object "Ring of Power"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 240
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 260
 	object
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 280
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 300
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 122
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 138
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 148
 	object
 		sprite planet/panels3
-		distance 800
+		distance 2980.49
 		period 360
 		offset 157
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 164
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 171
 	object
 		sprite planet/panels5
-		distance 800
+		distance 2980.49
 		period 360
 		offset 189
 	object
 		sprite planet/panels4
-		distance 800
+		distance 2980.49
 		period 360
 		offset 204
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 214
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 226
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 240
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 258
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 145
 	object
 		sprite planet/panels5
-		distance 830
+		distance 3104.78
 		period 360
 		offset 163
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 178
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 185
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 191
 	object
 		sprite planet/panels4
-		distance 830
+		distance 3104.78
 		period 360
 		offset 200
 	object
 		sprite planet/panels5
-		distance 830
+		distance 3104.78
 		period 360
 		offset 218
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 228
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 245
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 250
 
@@ -14239,8 +14239,8 @@ system Kiro'ku
 	pos -131.923 -884.46
 	government Wanderer
 	arrival 1500
-	habitable 1111.68
-	belt 1308
+	habitable 4294.97
+	belt 5145.95
 	haze _menu/haze-none
 	link Sich'ka'ara
 	link Ka'pru
@@ -14268,28 +14268,28 @@ system Kiro'ku
 	fleet "Wanderer Defense" 7000
 	object
 		sprite star/g5
-		distance 50.3456
+		distance 140.97
 		period 14.7951
 		offset 180
 	object
 		sprite star/k0
-		distance 64.6544
+		distance 185.49
 		period 14.7951
 	object
 		sprite planet/ice4
-		distance 228.654
+		distance 745.14
 		period 41.4801
 	object
 		sprite planet/rock10-b
-		distance 664.814
+		distance 2427.22
 		period 205.646
 	object "Var' Kar'i'i"
 		sprite planet/forest1-b
-		distance 948.574
+		distance 3600.93
 		period 350.491
 	object
 		sprite planet/desert5
-		distance 1482.38
+		distance 5914.42
 		period 684.717
 		object
 			sprite planet/rock0-b
@@ -14297,7 +14297,7 @@ system Kiro'ku
 			period 23.7306
 	object
 		sprite planet/gas10-b
-		distance 2974.99
+		distance 12849.34
 		period 1946.7
 		object
 			sprite planet/luna
@@ -14316,8 +14316,8 @@ system Kiru'kichi
 	pos -195.063 -662.343
 	government Wanderer
 	arrival 1500
-	habitable 2795
-	belt 1465
+	habitable 11985.5
+	belt 5837.33
 	haze _menu/haze-33
 	link Iyech'yek
 	asteroids "small rock" 11 5.032
@@ -14344,20 +14344,20 @@ system Kiru'kichi
 	fleet "Wanderer Defense" 2000
 	object
 		sprite star/f5
-		distance 53.7102
+		distance 151.34
 		period 12.3991
 		offset 180
 	object
 		sprite star/g0
-		distance 85.2898
+		distance 251.45
 		period 12.3991
 	object
 		sprite planet/cloud3-b
-		distance 255.7
+		distance 843.04
 		period 30.936
 	object
 		sprite planet/desert10-b
-		distance 575.39
+		distance 2068.04
 		period 104.427
 		object
 			sprite planet/io-b
@@ -14365,11 +14365,11 @@ system Kiru'kichi
 			period 16.5968
 	object
 		sprite planet/gas17-b
-		distance 1450.68
+		distance 5773.9
 		period 418.048
 	object "Varu Ek'lak'lai"
 		sprite planet/cloud0
-		distance 2756.64
+		distance 11802.23
 		period 1095.06
 
 system Kochab
@@ -14377,8 +14377,8 @@ system Kochab
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 320
-	belt 1912
+	habitable 1080.19
+	belt 7850.97
 	haze _menu/haze-67
 	link Zubeneschamali
 	link Ildaria
@@ -14402,19 +14402,19 @@ system Kochab
 		period 10
 	object Mere
 		sprite planet/ocean4
-		distance 246
+		distance 807.79
 		period 86.2755
 	object
 		sprite planet/venus-b
-		distance 521.25
+		distance 1853.55
 		period 266.106
 	object
 		sprite planet/dust6
-		distance 937.01
+		distance 3552.22
 		period 641.359
 	object
 		sprite planet/gas14
-		distance 2419.01
+		distance 10202.66
 		period 2660.37
 
 system "Kor Ak'Mari"
@@ -14422,8 +14422,8 @@ system "Kor Ak'Mari"
 	government Korath
 	attributes "korath" "wolf-rayet"
 	arrival 1500
-	habitable 625
-	belt 1606
+	habitable 2266.58
+	belt 6465.68
 	haze _menu/haze-full
 	asteroids "small metal" 13 3.024
 	asteroids "medium metal" 99 3.0744
@@ -14446,15 +14446,15 @@ system "Kor Ak'Mari"
 		period 100
 	object
 		sprite planet/lava6
-		distance 179.89
+		distance 571.86
 		period 38.6038
 	object
 		sprite planet/lava0-b
-		distance 492.58
+		distance 1740.96
 		period 174.918
 	object
 		sprite planet/ocean6-b
-		distance 874.19
+		distance 3288.8
 		period 413.551
 		object
 			sprite planet/callisto-b
@@ -14462,11 +14462,11 @@ system "Kor Ak'Mari"
 			period 16.2305
 	object
 		sprite planet/ice0-b
-		distance 1777.8
+		distance 7239.97
 		period 1199.35
 	object
 		sprite planet/oberon
-		distance 2107.64
+		distance 8750.67
 		period 1548.16
 
 system "Kor En'lakfar"
@@ -14474,8 +14474,8 @@ system "Kor En'lakfar"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 1080
-	belt 1115
+	habitable 4159.2
+	belt 4309.23
 	haze _menu/haze-133
 	link "Kor Men"
 	link "Kor Fel'tar"
@@ -14505,11 +14505,11 @@ system "Kor En'lakfar"
 		period 10
 	object
 		sprite planet/desert1-b
-		distance 286.027
+		distance 954.17
 		period 58.8789
 	object
 		sprite planet/ocean2
-		distance 866.215
+		distance 3255.51
 		period 310.304
 		object "Kessel Sepret"
 			sprite planet/station3k
@@ -14517,7 +14517,7 @@ system "Kor En'lakfar"
 			period 25.4803
 	object
 		sprite planet/gas8-b
-		distance 1769.36
+		distance 7201.72
 		period 905.882
 		object
 			sprite planet/mercury
@@ -14537,8 +14537,8 @@ system "Kor Fel'tar"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 455.625
-	belt 1444
+	habitable 1596.92
+	belt 5744.33
 	haze _menu/haze-blackbody
 	link "Kor En'lakfar"
 	link "Kor Men"
@@ -14568,11 +14568,11 @@ system "Kor Fel'tar"
 		period 10
 	object
 		sprite planet/ocean3
-		distance 249.66
+		distance 821.07
 		period 73.923
 	object
 		sprite planet/cloud8-b
-		distance 603.472
+		distance 2180.2
 		period 277.806
 		object "Septar Lorku"
 			sprite planet/station1k
@@ -14580,7 +14580,7 @@ system "Kor Fel'tar"
 			period 25.8519
 	object
 		sprite planet/gas2-b
-		distance 1750.5
+		distance 7116.32
 		period 1372.46
 		object
 			sprite planet/io
@@ -14604,8 +14604,8 @@ system "Kor Men"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 2340
-	belt 1260
+	habitable 9832.01
+	belt 4936.43
 	haze _menu/haze-blackbody
 	link "Kor En'lakfar"
 	link "Kor Fel'tar"
@@ -14631,28 +14631,28 @@ system "Kor Men"
 	fleet "Korath Home" 600
 	object
 		sprite star/f5-old
-		distance 33.3868
+		distance 89.89
 		period 11.5563
 	object
 		sprite star/g5
-		distance 91.6132
+		distance 272.02
 		period 11.5563
 		offset 180
 	object
 		sprite planet/gas3-hot
-		distance 361.863
+		distance 1237.5
 		period 56.9205
 	object
 		sprite planet/rock6
-		distance 765.073
+		distance 2836.45
 		period 174.987
 	object
 		sprite planet/ocean4
-		distance 1262.32
+		distance 4946.53
 		period 370.858
 	object
 		sprite planet/ocean6
-		distance 2075.77
+		distance 8603.41
 		period 782.023
 		object "Gresku Fodar"
 			sprite planet/station2k
@@ -14660,7 +14660,7 @@ system "Kor Men"
 			period 22.7597
 	object
 		sprite planet/rhea
-		distance 2981.5
+		distance 12880.7
 		period 1346.18
 
 system "Kor Nor'peli"
@@ -14668,8 +14668,8 @@ system "Kor Nor'peli"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 590.625
-	belt 1213
+	habitable 2128.81
+	belt 4732.17
 	haze _menu/haze-blackbody
 	link "Kor Tar'bei"
 	asteroids "small rock" 2 3.7932
@@ -14693,24 +14693,24 @@ system "Kor Nor'peli"
 	fleet "Korath Home" 500
 	object
 		sprite star/k0-old
-		distance 25.4857
+		distance 66.91
 		period 19.3783
 	object
 		sprite star/m4
-		distance 86.0143
+		distance 253.8
 		period 19.3783
 		offset 180
 	object
 		sprite planet/dust6
-		distance 285.024
+		distance 950.47
 		period 79.2003
 	object "Far'en Lai"
 		sprite planet/forest0
-		distance 595.274
+		distance 2147.39
 		period 239.045
 	object
 		sprite planet/gas10-b
-		distance 1192.96
+		distance 4645.35
 		period 678.175
 		object "Safaresk Enlai"
 			sprite planet/station2k
@@ -14718,11 +14718,11 @@ system "Kor Nor'peli"
 			period 18.3607
 	object
 		sprite planet/dust4-b
-		distance 2146.4
+		distance 8930.11
 		period 1636.7
 	object
 		sprite planet/gas9
-		distance 3036.01
+		distance 13143.62
 		period 2753.33
 		object
 			sprite planet/tethys
@@ -14734,8 +14734,8 @@ system "Kor Tar'bei"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 214.375
-	belt 1614
+	habitable 693.94
+	belt 6501.53
 	haze _menu/haze-blackbody
 	link "Kor Nor'peli"
 	link "Kor Zena'i"
@@ -14764,7 +14764,7 @@ system "Kor Tar'bei"
 		period 10
 	object
 		sprite planet/ocean6-b
-		distance 389.134
+		distance 1341.08
 		period 209.711
 		object "Sessiliki Far"
 			sprite planet/station1k
@@ -14772,7 +14772,7 @@ system "Kor Tar'bei"
 			period 21.1261
 	object
 		sprite planet/fog0
-		distance 1250.5
+		distance 4895.07
 		period 1208.09
 		object
 			sprite planet/rhea-b
@@ -14780,11 +14780,11 @@ system "Kor Tar'bei"
 			period 18.4461
 	object
 		sprite planet/ice0
-		distance 1882.66
+		distance 7716.95
 		period 2231.67
 	object
 		sprite planet/gas15
-		distance 2565.55
+		distance 10893.87
 		period 3550.12
 
 system "Kor Zena'i"
@@ -14792,8 +14792,8 @@ system "Kor Zena'i"
 	government Korath
 	attributes "korath"
 	arrival 1500
-	habitable 703.125
-	belt 1866
+	habitable 2582.82
+	belt 7640.95
 	haze _menu/haze-blackbody
 	link "Kor Tar'bei"
 	asteroids "small rock" 5 6.2205
@@ -14813,16 +14813,16 @@ system "Kor Zena'i"
 	fleet "Korath Home" 1100
 	object
 		sprite star/g5-old
-		distance 8.94444
+		distance 21.37
 		period 10.8953
 	object
 		sprite star/m8
-		distance 71.5556
+		distance 207.34
 		period 10.8953
 		offset 180
 	object
 		sprite planet/rock12-b
-		distance 484.416
+		distance 1709.04
 		period 160.831
 		object
 			sprite planet/lava0-b
@@ -14830,11 +14830,11 @@ system "Kor Zena'i"
 			period 19.718
 	object
 		sprite planet/ocean5-b
-		distance 981.376
+		distance 3739.48
 		period 463.764
 	object
 		sprite planet/gas16-b
-		distance 2043.67
+		distance 8455.36
 		period 1393.67
 		object "Separa Tiklar"
 			sprite planet/station3k
@@ -14846,8 +14846,8 @@ system Kornephoros
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 911.25
-	belt 1168
+	habitable 3443.95
+	belt 4537.45
 	link Sabik
 	link Aldhibain
 	link Sargas
@@ -14879,20 +14879,20 @@ system Kornephoros
 	fleet "Human Miners" 3000
 	object
 		sprite star/k0
-		distance 57.5
+		distance 163.09
 		period 16.3414
 		offset 180
 	object
 		sprite star/k0
-		distance 57.5
+		distance 163.09
 		period 16.3414
 	object
 		sprite planet/ganymede
-		distance 327.16
+		distance 1106.94
 		period 78.4118
 	object Deep
 		sprite planet/ocean9
-		distance 739.16
+		distance 2730.06
 		period 266.286
 		object Clink
 			sprite planet/luna
@@ -14900,11 +14900,11 @@ system Kornephoros
 			period 20.8235
 	object
 		sprite planet/ice7
-		distance 1501.2
+		distance 5998.01
 		period 770.724
 	object
 		sprite planet/gas15-b
-		distance 2966.29
+		distance 12807.44
 		period 2140.73
 		object
 			sprite planet/miranda-b
@@ -14928,8 +14928,8 @@ system Korsmanath
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1775
+	habitable 1717.88
+	belt 7227.28
 	link Feroteri
 	link Farbutero
 	asteroids "small rock" 2 2.4123
@@ -14953,15 +14953,15 @@ system Korsmanath
 		period 10
 	object
 		sprite planet/rock8-b
-		distance 175.21
+		distance 555.48
 		period 42.051
 	object "Kasichara Fet"
 		sprite planet/desert3
-		distance 469.3
+		distance 1650.08
 		period 184.338
 	object
 		sprite planet/gas0-b
-		distance 1202.55
+		distance 4686.87
 		period 756.124
 		object
 			sprite planet/dust7
@@ -14973,7 +14973,7 @@ system Korsmanath
 			period 25.1349
 	object
 		sprite planet/gas5-b
-		distance 2739.24
+		distance 11719.2
 		period 2599.46
 		object
 			sprite planet/lava0
@@ -14989,8 +14989,8 @@ system Kraz
 	government Republic
 	attributes "rim" 
 	arrival 1500
-	habitable 1080
-	belt 1056
+	habitable 4159.2
+	belt 4056.64
 	haze _menu/haze-67
 	link Mimosa
 	asteroids "small rock" 1 7.2072
@@ -15021,7 +15021,7 @@ system Kraz
 		period 10
 	object
 		sprite planet/rock2-b
-		distance 311.49
+		distance 1048.48
 		period 66.9136
 		object
 			sprite planet/dust2-b
@@ -15029,7 +15029,7 @@ system Kraz
 			period 22.3285
 	object Rust
 		sprite planet/forest6
-		distance 903.7
+		distance 3412.28
 		period 330.662
 		object
 			sprite planet/io-b
@@ -15037,11 +15037,11 @@ system Kraz
 			period 17.1483
 	object
 		sprite planet/rock15
-		distance 1258.06
+		distance 4927.98
 		period 543.125
 	object
 		sprite planet/gas17
-		distance 2011.3
+		distance 8306.34
 		period 1097.9
 		object
 			sprite planet/mercury-b
@@ -15057,8 +15057,8 @@ system Kugel
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1051
+	habitable 2266.58
+	belt 4035.3
 	link Acamar
 	asteroids "small rock" 58 3.234
 	asteroids "medium rock" 24 2.2792
@@ -15087,23 +15087,23 @@ system Kugel
 		period 10
 	object
 		sprite planet/desert0-b
-		distance 155.36
+		distance 486.52
 		period 30.9834
 	object
 		sprite planet/gas15-b
-		distance 506.61
+		distance 1795.97
 		period 182.444
 	object
 		sprite planet/rock5-b
-		distance 874.02
+		distance 3288.09
 		period 413.43
 	object
 		sprite planet/miranda
-		distance 1147.31
+		distance 4448.21
 		period 621.786
 	object
 		sprite planet/gas5
-		distance 2997.35
+		distance 12957.09
 		period 2625.59
 		object
 			sprite planet/luna-b
@@ -15127,8 +15127,8 @@ system Kursa
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 455
-	belt 1624
+	habitable 1594.5
+	belt 6546.37
 	haze _menu/haze-67
 	link Elnath
 	link Aldebaran
@@ -15153,36 +15153,36 @@ system Kursa
 	fleet "Large Republic" 8000
 	object
 		sprite star/k5
-		distance 27.5934
+		distance 72.98
 		period 16.8182
 		offset 180
 	object
 		sprite star/m4
-		distance 65.4066
+		distance 187.86
 		period 16.8182
 	object Farseer
 		sprite planet/ocean2
-		distance 357.847
+		distance 1222.32
 		period 126.94
 	object
 		sprite planet/lava1
-		distance 680.007
+		distance 2488.81
 		period 332.525
 	object
 		sprite planet/rock7
-		distance 1344.26
+		distance 5304.81
 		period 924.225
 	object
 		sprite planet/gas7-b
-		distance 1936.75
+		distance 7964.21
 		period 1598.32
 
 system "Last Word"
 	pos -1145.59 495.051
 	government Coalition
 	arrival 1500
-	habitable 625
-	belt 1761
+	habitable 2266.58
+	belt 7163.85
 	link "Silver Bell"
 	link "Fell Omen"
 	link Quaru
@@ -15214,7 +15214,7 @@ system "Last Word"
 		period 10
 	object
 		sprite planet/cloud8-b
-		distance 318.56
+		distance 1074.82
 		period 90.9718
 		object
 			sprite planet/rock3-b
@@ -15222,23 +15222,23 @@ system "Last Word"
 			period 19.1658
 	object "Gentle Rain"
 		sprite planet/forest6-b
-		distance 649
+		distance 2363.28
 		period 264.537
 	object
 		sprite planet/rock4
-		distance 893.49
+		distance 3369.5
 		period 427.321
 	object
 		sprite planet/forest1
-		distance 1172.25
+		distance 4555.81
 		period 642.17
 	object
 		sprite planet/rock1
-		distance 1383.46
+		distance 5477.12
 		period 823.322
 	object
 		sprite planet/gas1-b
-		distance 4922.46
+		distance 22542.61
 		period 5525.78
 
 system Lesath
@@ -15246,8 +15246,8 @@ system Lesath
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1715
-	belt 1865
+	habitable 6955.87
+	belt 7636.39
 	link Atria
 	link Shaula
 	link Girtab
@@ -15280,7 +15280,7 @@ system Lesath
 		period 10
 	object
 		sprite planet/rock4
-		distance 366.61
+		distance 1255.47
 		period 67.8007
 		object
 			sprite planet/rhea
@@ -15288,15 +15288,15 @@ system Lesath
 			period 21.2152
 	object
 		sprite planet/venus
-		distance 780.86
+		distance 2901.46
 		period 210.76
 	object
 		sprite planet/ocean1-b
-		distance 1069.07
+		distance 4112.46
 		period 337.627
 	object
 		sprite planet/desert6-b
-		distance 1577.48
+		distance 6338.04
 		period 605.165
 		object
 			sprite planet/oberon
@@ -15304,7 +15304,7 @@ system Lesath
 			period 18.9922
 	object
 		sprite planet/dust0
-		distance 2628.29
+		distance 11191.26
 		period 1301.48
 
 system Levana
@@ -15312,8 +15312,8 @@ system Levana
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 2798.68
-	belt 1202
+	habitable 12003.1
+	belt 4684.49
 	haze _menu/haze-red
 	link Coluber
 	asteroids "medium rock" 3 10.005
@@ -15338,32 +15338,32 @@ system Levana
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/giant
-		distance 17.197
+		distance 43.55
 		period 9.08241
 		offset 180
 	object
 		sprite star/k5
-		distance 95.803
+		distance 285.73
 		period 9.08241
 	object
 		sprite planet/dust1-b
-		distance 215.093
+		distance 696.51
 		period 23.8519
 	object
 		sprite planet/venus
-		distance 438.933
+		distance 1532.28
 		period 69.5314
 	object
 		sprite planet/desert1
-		distance 665.023
+		distance 2428.06
 		period 129.67
 	object
 		sprite planet/cloud1
-		distance 922.583
+		distance 3491.54
 		period 211.881
 	object
 		sprite planet/neptune-b
-		distance 3359.19
+		distance 14713.74
 		period 1472.09
 		object
 			sprite planet/rock17-b
@@ -15383,8 +15383,8 @@ system Limen
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1715
-	belt 1463
+	habitable 6955.87
+	belt 5828.47
 	haze _menu/haze-33
 	link Orbona
 	link Terminus
@@ -15409,15 +15409,15 @@ system Limen
 		period 10
 	object
 		sprite planet/venus
-		distance 238.96
+		distance 782.3
 		period 35.6793
 	object
 		sprite planet/lava3
-		distance 445.21
+		distance 1556.56
 		period 90.7351
 	object
 		sprite planet/gas2-b
-		distance 1297.5
+		distance 5100.04
 		period 451.429
 		object
 			sprite planet/europa-b
@@ -15425,7 +15425,7 @@ system Limen
 			period 18.4393
 	object
 		sprite planet/uranus
-		distance 2331.5
+		distance 9792.22
 		period 1087.38
 		object
 			sprite planet/dust5
@@ -15438,7 +15438,7 @@ system Lire
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 1080
+	habitable 4159.2
 	link Fearis
 	link Fereti
 	link Giribea
@@ -15465,11 +15465,11 @@ system Lire
 		period 10
 	object
 		sprite planet/dust2
-		distance 180.81
+		distance 575.09
 		period 29.5925
 	object
 		sprite planet/desert2-b
-		distance 676.17
+		distance 2473.24
 		period 214.009
 		object
 			sprite planet/rock0-b
@@ -15477,15 +15477,15 @@ system Lire
 			period 20.119
 	object
 		sprite planet/ice1
-		distance 1019.41
+		distance 3900.79
 		period 396.161
 	object Retilie
 		sprite planet/water1
-		distance 1361.41
+		distance 5380.13
 		period 611.409
 	object
 		sprite planet/browndwarf-l
-		distance 2307.37
+		distance 9679.36
 		period 1349.04
 		object
 			sprite planet/miranda-b
@@ -15501,8 +15501,8 @@ system Lolami
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1215
-	belt 1072
+	habitable 4740.84
+	belt 4124.98
 	link "Tania Australis"
 	asteroids "small rock" 68 1.6926
 	asteroids "medium rock" 55 1.6653
@@ -15529,16 +15529,16 @@ system Lolami
 	fleet "Human Miners" 3000
 	object
 		sprite star/g0
-		distance 11
+		distance 26.76
 		period 11.3038
 		offset 180
 	object
 		sprite star/m4
-		distance 88
+		distance 260.25
 		period 11.3038
 	object
 		sprite planet/gas14-b
-		distance 680.25
+		distance 2489.79
 		period 203.599
 		object
 			sprite planet/io-b
@@ -15550,7 +15550,7 @@ system Lolami
 			period 28.6494
 	object
 		sprite planet/gas0
-		distance 1704.86
+		distance 6910.12
 		period 807.802
 		object
 			sprite planet/rhea
@@ -15565,8 +15565,8 @@ system "Lom Tahr"
 	pos -94.0437 -446.586
 	government Hai
 	arrival 1500
-	habitable 2372.76
-	belt 1445
+	habitable 9985.52
+	belt 5748.76
 	link "Ya Hai"
 	link "Io Lowe"
 	link "Due Yoot"
@@ -15601,12 +15601,12 @@ system "Lom Tahr"
 		period 10
 	object
 		sprite planet/desert8-b
-		distance 170.795
+		distance 540.07
 		period 18.3293
 		offset 149.808
 	object
 		sprite planet/uranus
-		distance 554.485
+		distance 1984.94
 		period 107.218
 		offset 3.25911
 		object
@@ -15616,7 +15616,7 @@ system "Lom Tahr"
 			offset 93.1794
 	object
 		sprite planet/gas7
-		distance 1337.49
+		distance 5275.11
 		period 401.672
 		offset 138.785
 		object
@@ -15629,7 +15629,7 @@ system "Lom Tahr"
 			period 23.1936
 	object
 		sprite planet/gas8
-		distance 2759.78
+		distance 11817.22
 		period 1190.55
 		offset 21.8728
 		object
@@ -15642,8 +15642,8 @@ system "Lone Cloud"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 233.28
-	belt 1730
+	habitable 761.8
+	belt 7023.62
 	link "Four Pillars"
 	asteroids "medium rock" 119 4.732
 	asteroids "large rock" 30 7.1344
@@ -15674,19 +15674,19 @@ system "Lone Cloud"
 		period 10
 	object "Vibrant Water"
 		sprite planet/cloud1
-		distance 219.84
+		distance 713.49
 		period 85.3653
 	object
 		sprite planet/ice0
-		distance 581.08
+		distance 2090.71
 		period 366.839
 	object
 		sprite planet/cloud0
-		distance 954.33
+		distance 3625.2
 		period 772.092
 	object
 		sprite planet/io
-		distance 2146.74
+		distance 8931.69
 		period 2604.9
 
 system Lucina
@@ -15694,8 +15694,8 @@ system Lucina
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 320
-	belt 1466
+	habitable 1080.19
+	belt 5841.77
 	haze _menu/haze-red
 	link Parca
 	link Coluber
@@ -15725,15 +15725,15 @@ system Lucina
 		period 10
 	object
 		sprite planet/rock15-b
-		distance 166.96
+		distance 526.71
 		period 48.2396
 	object "Far Monad"
 		sprite planet/ocean4
-		distance 366.05
+		distance 1253.35
 		period 156.601
 	object
 		sprite planet/uranus
-		distance 993.3
+		distance 3789.98
 		period 700.012
 		object
 			sprite planet/io-b
@@ -15741,7 +15741,7 @@ system Lucina
 			period 12.8165
 	object
 		sprite planet/gas11-b
-		distance 2721.26
+		distance 11633.47
 		period 3174.24
 		object
 			sprite planet/dust1-b
@@ -15753,8 +15753,8 @@ system Lurata
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 455.625
-	belt 1151
+	habitable 1596.92
+	belt 4464.12
 	haze _menu/haze-133
 	link Dabih
 	link Albireo
@@ -15785,7 +15785,7 @@ system Lurata
 		period 10
 	object
 		sprite planet/ice1
-		distance 400.51
+		distance 1384.53
 		period 150.202
 		object
 			sprite planet/lava0-b
@@ -15793,7 +15793,7 @@ system Lurata
 			period 18.3265
 	object
 		sprite planet/gas8
-		distance 1179.52
+		distance 4587.22
 		period 759.127
 		object
 			sprite planet/oberon
@@ -15809,7 +15809,7 @@ system Lurata
 			period 46.1144
 	object
 		sprite planet/gas5-b
-		distance 2068.68
+		distance 8570.69
 		period 1763.18
 
 system Makferuti
@@ -15817,8 +15817,8 @@ system Makferuti
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 621.68
-	belt 1782
+	habitable 2253.24
+	belt 7259.01
 	link Asikafarnut
 	asteroids "small rock" 18 5.2706
 	asteroids "medium rock" 250 3.3212
@@ -15841,28 +15841,28 @@ system Makferuti
 	fleet "Large Kor Sestor" 5000
 	object
 		sprite star/k0
-		distance 18.2409
+		distance 46.44
 		period 12.3508
 		offset 180
 	object
 		sprite star/m8
-		distance 65.7591
+		distance 188.97
 		period 12.3508
 	object
 		sprite planet/desert3
-		distance 259.319
+		distance 856.23
 		period 66.9928
 	object "Drekag Firask"
 		sprite planet/ocean9
-		distance 690.569
+		distance 2531.71
 		period 291.13
 	object
 		sprite planet/dust6-b
-		distance 1108.57
+		distance 4281.62
 		period 592.135
 	object
 		sprite planet/rock6-b
-		distance 1441.13
+		distance 5731.64
 		period 877.669
 		object
 			sprite planet/rock17
@@ -15870,7 +15870,7 @@ system Makferuti
 			period 24.0239
 	object
 		sprite planet/gas3
-		distance 2858.22
+		distance 12288.18
 		period 2451.43
 		object
 			sprite planet/callisto-b
@@ -15894,8 +15894,8 @@ system Markab
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1411
+	habitable 2266.58
+	belt 5598.51
 	haze _menu/haze-133
 	link "Delta Capricorni"
 	link Scheat
@@ -15930,15 +15930,15 @@ system Markab
 		period 10
 	object
 		sprite planet/rock19
-		distance 172.09
+		distance 544.58
 		period 36.1205
 	object Hephaestus
 		sprite planet/forest3
-		distance 522.53
+		distance 1858.6
 		period 191.112
 	object
 		sprite planet/uranus-b
-		distance 1332.97
+		distance 5255.29
 		period 778.665
 		object
 			sprite planet/dust4
@@ -15954,7 +15954,7 @@ system Markab
 			period 38.2553
 	object
 		sprite planet/gas7-b
-		distance 3006.18
+		distance 12999.67
 		period 2637.2
 		object
 			sprite planet/oberon-b
@@ -15978,8 +15978,8 @@ system Markeb
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 455.625
-	belt 1556
+	habitable 1596.92
+	belt 6242.09
 	haze _menu/haze-33
 	link Avior
 	asteroids "small rock" 23 5.0895
@@ -16012,15 +16012,15 @@ system Markeb
 		period 10
 	object
 		sprite planet/lava0-b
-		distance 157.31
+		distance 493.26
 		period 36.9735
 	object Bivrost
 		sprite planet/forest2
-		distance 429.15
+		distance 1494.52
 		period 166.598
 	object
 		sprite planet/gas7
-		distance 967.99
+		distance 3682.88
 		period 564.368
 		object
 			sprite planet/dust4
@@ -16028,7 +16028,7 @@ system Markeb
 			period 11.6896
 	object
 		sprite planet/cloud0
-		distance 1906.67
+		distance 7826.6
 		period 1560.16
 		object Alexandria
 			sprite planet/station7
@@ -16036,7 +16036,7 @@ system Markeb
 			period 29.3849
 	object
 		sprite planet/miranda
-		distance 2787.49
+		distance 11949.6
 		period 2757.89
 
 system Matar
@@ -16044,8 +16044,8 @@ system Matar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 455.625
-	belt 1308
+	habitable 1596.92
+	belt 5145.95
 	haze _menu/haze-133
 	link Persian
 	link Scheat
@@ -16071,11 +16071,11 @@ system Matar
 		period 10
 	object
 		sprite planet/rock4
-		distance 183.39
+		distance 584.15
 		period 46.5393
 	object Antipode
 		sprite planet/ocean5
-		distance 606.63
+		distance 2192.85
 		period 279.99
 		object
 			sprite planet/rock14
@@ -16083,11 +16083,11 @@ system Matar
 			period 17.1091
 	object
 		sprite planet/tethys-b
-		distance 1400.52
+		distance 5552.28
 		period 982.178
 	object
 		sprite planet/gas14-b
-		distance 2811.52
+		distance 12064.52
 		period 2793.62
 		object
 			sprite planet/ice0
@@ -16103,8 +16103,8 @@ system Mebla
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 486.68
-	belt 1114
+	habitable 1717.88
+	belt 4304.94
 	link Debrugt
 	link Pelubta
 	link Ablodab
@@ -16134,11 +16134,11 @@ system Mebla
 		period 10
 	object
 		sprite planet/dust5-b
-		distance 131.56
+		distance 405.08
 		period 27.3605
 	object "Mebla's Portion"
 		sprite planet/ocean4
-		distance 430.52
+		distance 1499.8
 		period 161.968
 		object
 			sprite planet/oberon-b
@@ -16146,11 +16146,11 @@ system Mebla
 			period 13.9639
 	object
 		sprite planet/desert7
-		distance 955.16
+		distance 3628.71
 		period 535.245
 	object
 		sprite planet/gas0
-		distance 2427.45
+		distance 10242.34
 		period 2168.52
 		object
 			sprite planet/europa-b
@@ -16162,8 +16162,8 @@ system Mebsuta
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 670
-	belt 1740
+	habitable 2448.22
+	belt 7068.83
 	haze _menu/haze-33
 	link Mirzam
 	asteroids "small rock" 1 4.1412
@@ -16190,20 +16190,20 @@ system Mebsuta
 	fleet "Small Republic" 12000
 	object
 		sprite star/k0
-		distance 37.1157
+		distance 100.94
 		period 19.3068
 		offset 180
 	object
 		sprite star/m0
-		distance 78.8843
+		distance 230.78
 		period 19.3068
 	object
 		sprite planet/gas0-hot
-		distance 305.544
+		distance 1026.38
 		period 82.5342
 	object Featherweight
 		sprite planet/forest3-b
-		distance 655.034
+		distance 2387.65
 		period 259.071
 		object
 			sprite planet/desert4
@@ -16211,11 +16211,11 @@ system Mebsuta
 			period 17.9915
 	object
 		sprite planet/ocean8
-		distance 1066.24
+		distance 4100.36
 		period 538.031
 	object
 		sprite planet/rock2-b
-		distance 1590.45
+		distance 6396.05
 		period 980.177
 		object
 			sprite planet/europa-b
@@ -16223,7 +16223,7 @@ system Mebsuta
 			period 16.1817
 	object
 		sprite planet/gas10
-		distance 4225.69
+		distance 19009.36
 		period 4244.92
 		object
 			sprite planet/dust3-b
@@ -16239,8 +16239,8 @@ system Meftarkata
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 2201.68
-	belt 1232
+	habitable 9186.69
+	belt 4814.63
 	haze _menu/haze-133
 	link Skeruto
 	link Dokdobaru
@@ -16265,28 +16265,28 @@ system Meftarkata
 	fleet "Large Quarg" 1000
 	object
 		sprite star/f5
-		distance 21.8839
+		distance 56.65
 		period 8.39722
 		offset 180
 	object
 		sprite star/k0
-		distance 77.1161
+		distance 225.1
 		period 8.39722
 	object
 		sprite planet/ice5
-		distance 312.076
+		distance 1050.66
 		period 46.9974
 	object
 		sprite planet/desert9
-		distance 698.326
+		distance 2563.27
 		period 157.315
 	object
 		sprite planet/rock17-b
-		distance 998.576
+		distance 3812.34
 		period 269.001
 	object
 		sprite planet/gas10-b
-		distance 2327.58
+		distance 9773.88
 		period 957.279
 		object
 			sprite planet/europa-b
@@ -16301,8 +16301,8 @@ system "Mei Yohn"
 	pos -106.757 -581.698
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1075
+	habitable 1482.07
+	belt 4137.81
 	haze _menu/haze-67
 	link "Zuba Zub"
 	link "Ula Mon"
@@ -16332,15 +16332,15 @@ system "Mei Yohn"
 		period 10
 	object
 		sprite planet/cloud8-b
-		distance 228.21
+		distance 743.54
 		period 66.8187
 	object Darkmetal
 		sprite planet/rock1
-		distance 578.21
+		distance 2079.27
 		period 269.479
 	object
 		sprite planet/gas14-b
-		distance 1432.42
+		distance 5693.12
 		period 1050.76
 		object
 			sprite planet/callisto
@@ -16352,7 +16352,7 @@ system "Mei Yohn"
 			period 25.5315
 	object
 		sprite planet/gas15
-		distance 2245.38
+		distance 9390.07
 		period 2062.2
 		object
 			sprite planet/desert4
@@ -16368,8 +16368,8 @@ system Mekislepti
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 1705
-	belt 1673
+	habitable 6910.75
+	belt 6766.55
 	haze _menu/haze-133
 	link Fornarep
 	link Kaliptari
@@ -16400,28 +16400,28 @@ system Mekislepti
 	fleet "Kor Mereti Miners" 2000
 	object
 		sprite star/g0
-		distance 38.4897
+		distance 105.04
 		period 10.4227
 	object
 		sprite star/g5
-		distance 66.5103
+		distance 191.34
 		period 10.4227
 		offset 180
 	object
 		sprite planet/mars
-		distance 305.67
+		distance 1026.85
 		period 51.7699
 	object
 		sprite planet/cloud0-b
-		distance 556.96
+		distance 1994.76
 		period 127.331
 	object "Aresepru Nat"
 		sprite planet/water1
-		distance 1697.45
+		distance 6876.7
 		period 677.476
 	object
 		sprite planet/neptune
-		distance 2600.81
+		distance 11060.9
 		period 1284.88
 		object "Merask Fortuno"
 			sprite planet/station1k
@@ -16433,8 +16433,8 @@ system Meblumem
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 2201.68
-	belt 1794
+	habitable 9186.69
+	belt 7313.45
 	link "Sol Arach"
 	link Pelubta
 	link Gupta
@@ -16458,24 +16458,24 @@ system Meblumem
 	fleet Heliarch 400
 	object
 		sprite star/f5
-		distance 28.2943
+		distance 75.01
 		period 12.3452
 	object
 		sprite star/k0
-		distance 99.7057
+		distance 298.56
 		period 12.3452
 		offset 180
 	object
 		sprite planet/desert4
-		distance 521.254
+		distance 1853.57
 		period 101.451
 	object
 		sprite planet/desert5-b
-		distance 817.478
+		distance 3052.84
 		period 199.249
 	object
 		sprite planet/fog0
-		distance 1278.61
+		distance 5017.55
 		period 389.753
 		object
 			sprite planet/rock7
@@ -16483,15 +16483,15 @@ system Meblumem
 			period 17.2245
 	object
 		sprite planet/desert6
-		distance 1710.08
+		distance 6933.67
 		period 602.849
 	object "Corral of Meblumem"
 		sprite planet/forest1
-		distance 1975.08
+		distance 8139.93
 		period 748.274
 	object
 		sprite planet/gas4
-		distance 2986.38
+		distance 12904.21
 		period 1391.23
 
 system Men
@@ -16499,8 +16499,8 @@ system Men
 	government Pirate
 	attributes "south"
 	arrival 1500
-	habitable 320
-	belt 1531
+	habitable 1080.19
+	belt 6130.61
 	haze _menu/haze-33
 	link "Beta Lupi"
 	asteroids "small rock" 9 3.504
@@ -16530,15 +16530,15 @@ system Men
 		period 10
 	object Thule
 		sprite planet/forest4
-		distance 203.64
+		distance 655.7
 		period 64.98
 	object
 		sprite planet/ocean0
-		distance 473.08
+		distance 1664.8
 		period 230.084
 	object
 		sprite planet/gas9
-		distance 1265.37
+		distance 4959.82
 		period 1006.49
 		object
 			sprite planet/dust2
@@ -16554,7 +16554,7 @@ system Men
 			period 46.1144
 	object
 		sprite planet/gas13-b
-		distance 2504.61
+		distance 10605.84
 		period 2802.82
 		object "Smuggler's Den"
 			sprite planet/station15
@@ -16566,8 +16566,8 @@ system Menkalinan
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 3430
-	belt 1424
+	habitable 15060.23
+	belt 5655.91
 	haze _menu/haze-67
 	link Capella
 	link Castor
@@ -16598,20 +16598,20 @@ system Menkalinan
 	fleet "Republic Logistics" 2000
 	object
 		sprite star/f5-old
-		distance 58.5
+		distance 166.2
 		period 8.64354
 		offset 180
 	object
 		sprite star/f5
-		distance 58.5
+		distance 166.2
 		period 8.64354
 	object
 		sprite planet/desert8
-		distance 280.26
+		distance 932.93
 		period 32.0446
 	object
 		sprite planet/rock1-b
-		distance 662.22
+		distance 2416.72
 		period 116.39
 		object
 			sprite planet/callisto-b
@@ -16619,7 +16619,7 @@ system Menkalinan
 			period 21.8822
 	object
 		sprite planet/gas7-b
-		distance 1830.22
+		distance 7478.01
 		period 534.771
 		object
 			sprite planet/mercury
@@ -16635,8 +16635,8 @@ system Menkar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 455.625
-	belt 1634
+	habitable 1596.92
+	belt 6591.24
 	haze _menu/haze-133
 	link Zaurak
 	link Mirfak
@@ -16671,19 +16671,19 @@ system Menkar
 		period 10
 	object
 		sprite planet/desert2-b
-		distance 172.71
+		distance 546.75
 		period 42.5336
 	object Icefall
 		sprite planet/ice2
-		distance 413.52
+		distance 1434.39
 		period 157.58
 	object
 		sprite planet/cloud4
-		distance 742.77
+		distance 2744.85
 		period 379.348
 	object
 		sprite planet/gas9
-		distance 1719.01
+		distance 6973.98
 		period 1335.59
 		object "Oberon Station"
 			sprite planet/station5
@@ -16691,7 +16691,7 @@ system Menkar
 			period 13.6082
 	object
 		sprite planet/dust4-b
-		distance 4390.62
+		distance 19839.77
 		period 5451.86
 
 system Menkent
@@ -16699,8 +16699,8 @@ system Menkent
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 2340
-	belt 1728
+	habitable 9832.01
+	belt 7014.59
 	link Vega
 	link Rutilicus
 	link Cebalrai
@@ -16730,32 +16730,32 @@ system Menkent
 	fleet "Human Miners" 2000
 	object
 		sprite star/f5
-		distance 27.7778
+		distance 73.51
 		period 8.77005
 		offset 180
 	object
 		sprite star/g5
-		distance 76.2222
+		distance 222.24
 		period 8.77005
 	object
 		sprite planet/rock14-b
-		distance 341.472
+		distance 1160.61
 		period 52.1777
 	object
 		sprite planet/luna-b
-		distance 562.722
+		distance 2017.64
 		period 110.381
 	object
 		sprite planet/dust3-b
-		distance 875.722
+		distance 3295.2
 		period 214.29
 	object
 		sprite planet/dust4-b
-		distance 1199.28
+		distance 4672.71
 		period 343.427
 	object "New Austria"
 		sprite planet/ocean2
-		distance 1670.69
+		distance 6756.15
 		period 564.673
 		object
 			sprite planet/rock17-b
@@ -16763,7 +16763,7 @@ system Menkent
 			period 13.5253
 	object
 		sprite planet/gas13-b
-		distance 3293.05
+		distance 14390.88
 		period 1562.61
 
 system Merak
@@ -16771,8 +16771,8 @@ system Merak
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 1080.62
-	belt 1769
+	habitable 4161.85
+	belt 7200.09
 	haze _menu/haze-67
 	link Phecda
 	link Porrima
@@ -16804,32 +16804,32 @@ system Merak
 	fleet "Large Republic" 4000
 	object
 		sprite star/g5
-		distance 40.2658
+		distance 110.36
 		period 11.3561
 	object
 		sprite star/k0
-		distance 55.2342
+		distance 156.05
 		period 11.3561
 		offset 180
 	object
 		sprite planet/dust6
-		distance 244.494
+		distance 802.33
 		period 46.5185
 	object
 		sprite planet/lava6-b
-		distance 556.134
+		distance 1991.48
 		period 159.585
 	object
 		sprite planet/lava0
-		distance 789.024
+		distance 2935.14
 		period 269.686
 	object "New China"
 		sprite planet/forest4-b
-		distance 1107.51
+		distance 4277.08
 		period 448.483
 	object
 		sprite planet/luna
-		distance 2504.4
+		distance 10604.85
 		period 1525.03
 
 system Mesuket
@@ -16837,8 +16837,8 @@ system Mesuket
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 425.92
-	belt 1189
+	habitable 1482.07
+	belt 4628.21
 	link Eshkoshtar
 	link Silikatakfar
 	link Eneremprukt
@@ -16861,11 +16861,11 @@ system Mesuket
 		period 10
 	object
 		sprite planet/mercury-b
-		distance 125.36
+		distance 384.11
 		period 27.2041
 	object
 		sprite planet/rock13
-		distance 569.491
+		distance 2044.55
 		period 263.406
 		object
 			sprite planet/station1kd
@@ -16873,7 +16873,7 @@ system Mesuket
 			period 25.3047
 	object
 		sprite planet/gas17-b
-		distance 1378.34
+		distance 5454.58
 		period 991.812
 		object
 			sprite planet/station3kd
@@ -16881,7 +16881,7 @@ system Mesuket
 			period 26.9888
 	object
 		sprite planet/gas4
-		distance 3615.31
+		distance 15971.01
 		period 4213.22
 		object
 			sprite planet/ice7-b
@@ -16905,8 +16905,8 @@ system Miaplacidus
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 455.625
-	belt 1236
+	habitable 1596.92
+	belt 4832.01
 	link Tejat
 	link Alphard
 	link Talita
@@ -16937,7 +16937,7 @@ system Miaplacidus
 		period 10
 	object Vinci
 		sprite planet/ocean7
-		distance 274.75
+		distance 912.69
 		period 85.342
 		object
 			sprite planet/ice8-b
@@ -16945,19 +16945,19 @@ system Miaplacidus
 			period 20.3008
 	object
 		sprite planet/rock3
-		distance 676
+		distance 2472.55
 		period 329.364
 	object
 		sprite planet/dust3
-		distance 873.29
+		distance 3285.04
 		period 483.609
 	object
 		sprite planet/water1
-		distance 1256.98
+		distance 4923.28
 		period 835.12
 	object
 		sprite planet/gas0
-		distance 3610.34
+		distance 15946.51
 		period 4065.17
 		object
 			sprite planet/dust4-b
@@ -16981,8 +16981,8 @@ system Miblulub
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 1080
-	belt 1757
+	habitable 4159.2
+	belt 7145.74
 	haze _menu/haze-133
 	link "Sol Arach"
 	link Blubipad
@@ -17020,7 +17020,7 @@ system Miblulub
 		period 10
 	object
 		sprite planet/desert6-b
-		distance 285.84
+		distance 953.48
 		period 58.821
 		object
 			sprite planet/rock7-b
@@ -17028,11 +17028,11 @@ system Miblulub
 			period 22.8905
 	object
 		sprite planet/ice3-b
-		distance 627.65
+		distance 2277.24
 		period 191.392
 	object "Miblulub's Plenty"
 		sprite planet/forest0-b
-		distance 1074.29
+		distance 4134.77
 		period 428.579
 		object
 			sprite planet/dust0
@@ -17040,7 +17040,7 @@ system Miblulub
 			period 17.6226
 	object
 		sprite planet/gas10
-		distance 2213.65
+		distance 9242.35
 		period 1267.69
 		object
 			sprite planet/io
@@ -17064,8 +17064,8 @@ system Mimosa
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 320
-	belt 1484
+	habitable 1080.19
+	belt 5921.61
 	haze _menu/haze-67
 	link Minkar
 	link Kraz
@@ -17096,19 +17096,19 @@ system Mimosa
 		period 10
 	object
 		sprite planet/rock13
-		distance 171.16
+		distance 541.34
 		period 50.0712
 	object Shorebreak
 		sprite planet/ocean9
-		distance 418.12
+		distance 1452.06
 		period 191.177
 	object
 		sprite planet/water0
-		distance 708.21
+		distance 2603.55
 		period 421.433
 	object
 		sprite planet/rhea-b
-		distance 2070.21
+		distance 8577.75
 		period 2106.23
 
 system Minkar
@@ -17116,8 +17116,8 @@ system Minkar
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 670
-	belt 1354
+	habitable 2448.22
+	belt 5347.57
 	haze _menu/haze-67
 	link Acrux
 	link Spica
@@ -17146,16 +17146,16 @@ system Minkar
 	fleet "Large Southern Pirates" 12000
 	object
 		sprite star/k0-old
-		distance 33.5961
+		distance 90.51
 		period 16.6267
 	object
 		sprite star/m0
-		distance 71.4039
+		distance 206.85
 		period 16.6267
 		offset 180
 	object
 		sprite planet/rock16
-		distance 409.064
+		distance 1417.29
 		period 127.853
 		object
 			sprite planet/rhea-b
@@ -17163,7 +17163,7 @@ system Minkar
 			period 24.0239
 	object
 		sprite planet/cloud1-b
-		distance 901.504
+		distance 3403.07
 		period 418.287
 		object
 			sprite planet/rock7
@@ -17171,11 +17171,11 @@ system Minkar
 			period 18.6328
 	object
 		sprite planet/luna-b
-		distance 1662.54
+		distance 6719.48
 		period 1047.57
 	object
 		sprite planet/desert4
-		distance 2872.75
+		distance 12357.86
 		period 2379.42
 
 system Mintaka
@@ -17183,8 +17183,8 @@ system Mintaka
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 775.625
-	belt 1753
+	habitable 2879.89
+	belt 7127.64
 	haze _menu/haze-67
 	link Almaaz
 	link Alnitak
@@ -17215,32 +17215,32 @@ system Mintaka
 	fleet "Human Miners" 2000
 	object
 		sprite star/k0
-		distance 34.4496
+		distance 93.03
 		period 10.9588
 		offset 180
 	object
 		sprite star/k5
-		distance 49.0504
+		distance 137.0
 		period 10.9588
 	object
 		sprite planet/rock11-b
-		distance 296.29
+		distance 992.07
 		period 73.2505
 	object
 		sprite planet/cloud0-b
-		distance 511.78
+		distance 1816.29
 		period 166.287
 	object
 		sprite planet/ice3-b
-		distance 938.02
+		distance 3556.47
 		period 412.622
 	object
 		sprite planet/gas8-b
-		distance 1798.98
+		distance 7336.05
 		period 1095.91
 	object
 		sprite planet/gas5
-		distance 4566.87
+		distance 20731.34
 		period 4432.64
 
 system Mirach
@@ -17248,8 +17248,8 @@ system Mirach
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 292.5
-	belt 1980
+	habitable 978.06
+	belt 8162.51
 	haze _menu/haze-133
 	link "Al Dhanab"
 	link Scheat
@@ -17281,20 +17281,20 @@ system Mirach
 	fleet "Human Miners" 3000
 	object
 		sprite star/m0
-		distance 21.1004
+		distance 54.44
 		period 16.4224
 		offset 180
 	object
 		sprite star/m8
-		distance 57.8996
+		distance 164.33
 		period 16.4224
 	object Placer
 		sprite planet/cloud8
-		distance 302.24
+		distance 1014.12
 		period 122.892
 	object
 		sprite planet/gas8-b
-		distance 699.45
+		distance 2567.85
 		period 432.645
 		object
 			sprite planet/rock7
@@ -17302,7 +17302,7 @@ system Mirach
 			period 14.5735
 	object
 		sprite planet/jupiter
-		distance 2004.06
+		distance 8273.05
 		period 2098.28
 		object
 			sprite planet/dust4
@@ -17318,8 +17318,8 @@ system Mirfak
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 320
-	belt 1887
+	habitable 1080.19
+	belt 7736.76
 	link Menkar
 	link Bellatrix
 	link Moktar
@@ -17351,15 +17351,15 @@ system Mirfak
 		period 10
 	object
 		sprite planet/rock5-b
-		distance 135.04
+		distance 416.9
 		period 35.0896
 	object Sunracer
 		sprite planet/forest4
-		distance 375.53
+		distance 1289.31
 		period 162.724
 	object
 		sprite planet/rock1
-		distance 761.49
+		distance 2821.71
 		period 469.874
 		object
 			sprite planet/rock17
@@ -17367,7 +17367,7 @@ system Mirfak
 			period 17.6303
 	object
 		sprite planet/ice8
-		distance 2077.85
+		distance 8613.01
 		period 2117.9
 
 system Mirzam
@@ -17375,8 +17375,8 @@ system Mirzam
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1080
-	belt 1025
+	habitable 4159.2
+	belt 3924.56
 	haze _menu/haze-67
 	link Canopus
 	link Betelgeuse
@@ -17410,23 +17410,23 @@ system Mirzam
 		period 10
 	object
 		sprite planet/lava5-b
-		distance 184.16
+		distance 586.85
 		period 30.4187
 	object
 		sprite planet/lava7-b
-		distance 425.17
+		distance 1479.19
 		period 106.707
 	object
 		sprite planet/cloud6
-		distance 754.58
+		distance 2793.32
 		period 252.293
 	object
 		sprite planet/io
-		distance 1523.47
+		distance 6097.08
 		period 723.767
 	object
 		sprite planet/gas14-b
-		distance 2805.76
+		distance 12036.96
 		period 1808.94
 		object
 			sprite planet/rock17
@@ -17438,8 +17438,8 @@ system Mizar
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1876
+	habitable 4159.2
+	belt 7686.56
 	haze _menu/haze-67
 	link Arcturus
 	link "Cor Caroli"
@@ -17464,23 +17464,23 @@ system Mizar
 		period 10
 	object
 		sprite planet/desert6
-		distance 192.09
+		distance 614.79
 		period 32.4045
 	object
 		sprite planet/ocean5
-		distance 656.13
+		distance 2392.08
 		period 204.566
 	object
 		sprite planet/rock2-b
-		distance 1169.17
+		distance 4542.5
 		period 486.592
 	object
 		sprite planet/miranda
-		distance 1462.81
+		distance 5827.63
 		period 680.973
 	object
 		sprite planet/gas6-b
-		distance 2654.3
+		distance 11314.79
 		period 1664.46
 		object
 			sprite planet/tethys
@@ -17492,8 +17492,8 @@ system Moktar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 455
-	belt 1888
+	habitable 1594.5
+	belt 7741.32
 	link Oblate
 	link Cardax
 	link Mirfak
@@ -17524,16 +17524,16 @@ system Moktar
 	fleet "Small Northern Pirates" 3000
 	object
 		sprite star/k5
-		distance 29.0769
+		distance 77.28
 		period 18.1925
 		offset 180
 	object
 		sprite star/m4
-		distance 68.9231
+		distance 198.98
 		period 18.1925
 	object
 		sprite planet/cloud4
-		distance 404.173
+		distance 1398.55
 		period 152.372
 		object
 			sprite planet/rock17-b
@@ -17541,19 +17541,19 @@ system Moktar
 			period 17.8463
 	object
 		sprite planet/dust0
-		distance 892.383
+		distance 3364.87
 		period 499.898
 	object
 		sprite planet/rock2
-		distance 1160.38
+		distance 4504.56
 		period 741.236
 	object
 		sprite planet/rhea
-		distance 1593.34
+		distance 6408.99
 		period 1192.66
 	object
 		sprite planet/rock3
-		distance 1988.1
+		distance 8199.71
 		period 1662.31
 
 system Mora
@@ -17561,8 +17561,8 @@ system Mora
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1176
+	habitable 1080.19
+	belt 4572.01
 	haze _menu/haze-67
 	link "Delta Velorum"
 	link "Tania Australis"
@@ -17595,11 +17595,11 @@ system Mora
 		period 10
 	object
 		sprite planet/desert9
-		distance 141
+		distance 437.21
 		period 37.4381
 	object
 		sprite planet/rock13-b
-		distance 596.21
+		distance 2151.13
 		period 325.525
 		object
 			sprite planet/ice0
@@ -17607,7 +17607,7 @@ system Mora
 			period 20.3374
 	object
 		sprite planet/gas5
-		distance 1825.62
+		distance 7457.09
 		period 1744.22
 		object
 			sprite planet/desert4-b
@@ -17623,8 +17623,8 @@ system Muhlifain
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 455.625
-	belt 1265
+	habitable 1596.92
+	belt 4958.21
 	haze _menu/haze-67
 	link Vindemiatrix
 	link Gacrux
@@ -17647,11 +17647,11 @@ system Muhlifain
 		period 10
 	object
 		sprite planet/fog0-b
-		distance 275.86
+		distance 916.76
 		period 85.8597
 	object "New Kansas"
 		sprite planet/ocean1
-		distance 720.47
+		distance 2653.59
 		period 362.393
 		object
 			sprite planet/ice0
@@ -17659,11 +17659,11 @@ system Muhlifain
 			period 20.6379
 	object
 		sprite planet/lava5-b
-		distance 1124.08
+		distance 4348.24
 		period 706.24
 	object
 		sprite planet/rock3-b
-		distance 2277.33
+		distance 9539.06
 		period 2036.55
 
 system Muphrid
@@ -17671,8 +17671,8 @@ system Muphrid
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 839.375
-	belt 1759
+	habitable 3143.73
+	belt 7154.8
 	link Menkent
 	link Porrima
 	asteroids "small rock" 10 4.7348
@@ -17697,32 +17697,32 @@ system Muphrid
 	fleet "Small Republic" 5000
 	object
 		sprite star/g5-old
-		distance 21.8366
+		distance 56.52
 		period 10.9152
 	object
 		sprite star/m0
-		distance 63.6634
+		distance 182.37
 		period 10.9152
 		offset 180
 	object
 		sprite planet/rock10
-		distance 382.203
+		distance 1314.68
 		period 103.163
 	object
 		sprite planet/ocean5
-		distance 680.643
+		distance 2491.39
 		period 245.167
 	object
 		sprite planet/desert10
-		distance 1088.08
+		distance 4193.78
 		period 495.536
 	object
 		sprite planet/io-b
-		distance 1593.44
+		distance 6409.44
 		period 878.187
 	object
 		sprite planet/dust1
-		distance 2405.68
+		distance 10140.02
 		period 1629.07
 
 system Naos
@@ -17730,8 +17730,8 @@ system Naos
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 625
-	belt 1045
+	habitable 2266.58
+	belt 4009.72
 	haze _menu/haze-67
 	link Regor
 	link Wezen
@@ -17765,7 +17765,7 @@ system Naos
 		period 10
 	object
 		sprite planet/cloud6-b
-		distance 284.04
+		distance 946.85
 		period 76.593
 		object
 			sprite planet/rock7-b
@@ -17773,19 +17773,19 @@ system Naos
 			period 17.0438
 	object Asgard
 		sprite planet/forest1-b
-		distance 698.29
+		distance 2563.13
 		period 295.239
 	object
 		sprite planet/cloud5-b
-		distance 1403.38
+		distance 5564.9
 		period 841.168
 	object
 		sprite planet/ice0
-		distance 1754.42
+		distance 7134.06
 		period 1175.76
 	object
 		sprite planet/gas9
-		distance 3348.18
+		distance 14659.94
 		period 3099.8
 		object
 			sprite planet/desert4
@@ -17805,8 +17805,8 @@ system Naper
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1715
-	belt 1445
+	habitable 6955.87
+	belt 5748.76
 	link Ascella
 	asteroids "small rock" 3 2.0757
 	asteroids "medium rock" 13 0.9724
@@ -17836,15 +17836,15 @@ system Naper
 		period 10
 	object
 		sprite planet/desert9
-		distance 156.44
+		distance 490.25
 		period 18.8995
 	object
 		sprite planet/lava6-b
-		distance 386.44
+		distance 1330.81
 		period 73.3755
 	object
 		sprite planet/gas13-b
-		distance 967.73
+		distance 3681.78
 		period 290.776
 		object
 			sprite planet/ganymede
@@ -17852,7 +17852,7 @@ system Naper
 			period 14.0112
 	object
 		sprite planet/gas16-b
-		distance 2043.82
+		distance 8456.05
 		period 892.466
 		object
 			sprite planet/desert4-b
@@ -17868,8 +17868,8 @@ system Nenia
 	government Uninhabited
 	attributes "ember waste" "void sprites" "archon"
 	arrival 1500
-	habitable 2340
-	belt 1343
+	habitable 9832.01
+	belt 5299.28
 	haze _menu/haze-red
 	link Ossipago
 	link Cardea
@@ -17899,20 +17899,20 @@ system Nenia
 	hazard "Ember Waste Base Storm" 25000
 	object
 		sprite star/f5-old
-		distance 31.5171
+		distance 84.4
 		period 10.5992
 	object
 		sprite star/g5-old
-		distance 86.4829
+		distance 255.32
 		period 10.5992
 		offset 180
 	object
 		sprite planet/desert6
-		distance 249.723
+		distance 821.3
 		period 32.6317
 	object Nasqueron
 		sprite planet/gas8
-		distance 880.683
+		distance 3315.93
 		period 216.113
 		object
 			sprite planet/rock3
@@ -17924,7 +17924,7 @@ system Nenia
 			period 26.6433
 	object
 		sprite planet/desert1-b
-		distance 1626.29
+		distance 6556.64
 		period 542.313
 		object
 			sprite planet/rhea
@@ -17932,7 +17932,7 @@ system Nenia
 			period 18.3981
 	object Slylandro
 		sprite planet/gas11
-		distance 3003.29
+		distance 12985.73
 		period 1360.97
 		object
 			sprite planet/dust4-b
@@ -17948,8 +17948,8 @@ system Nihal
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 534.375
-	belt 1329
+	habitable 1905.33
+	belt 5237.89
 	link Elnath
 	link Volax
 	link Sospi
@@ -17981,16 +17981,16 @@ system Nihal
 	fleet "Human Miners" 2000
 	object
 		sprite star/k5
-		distance 43.1257
+		distance 118.97
 		period 19.2863
 	object
 		sprite star/m0
-		distance 64.3743
+		distance 184.61
 		period 19.2863
 		offset 180
 	object Maelstrom
 		sprite planet/ice6
-		distance 361.684
+		distance 1236.83
 		period 119.023
 		object
 			sprite planet/oberon-b
@@ -17998,7 +17998,7 @@ system Nihal
 			period 20.7539
 	object
 		sprite planet/ocean9
-		distance 972.924
+		distance 3703.73
 		period 525.116
 		object
 			sprite planet/dust4-b
@@ -18006,7 +18006,7 @@ system Nihal
 			period 21.76
 	object
 		sprite planet/gas4-b
-		distance 2020.21
+		distance 8347.33
 		period 1571.21
 		object
 			sprite planet/dust7-b
@@ -18022,8 +18022,8 @@ system Nocte
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 135
-	belt 1304
+	habitable 416.76
+	belt 5128.45
 	link Vega
 	asteroids "small rock" 121 1.9558
 	asteroids "medium rock" 14 1.9096
@@ -18054,7 +18054,7 @@ system Nocte
 		period 10
 	object
 		sprite planet/desert8-b
-		distance 278.25
+		distance 925.54
 		period 159.789
 		object
 			sprite planet/ice7-b
@@ -18062,7 +18062,7 @@ system Nocte
 			period 23.7466
 	object
 		sprite planet/gas17
-		distance 973.25
+		distance 3705.11
 		period 1045.27
 		object
 			sprite planet/dust2
@@ -18074,7 +18074,7 @@ system Nocte
 			period 27.9019
 	object
 		sprite planet/gas2
-		distance 1709.01
+		distance 6928.84
 		period 2432.26
 		object
 			sprite planet/tethys-b
@@ -18082,7 +18082,7 @@ system Nocte
 			period 11.5481
 	object
 		sprite planet/miranda
-		distance 2260.97
+		distance 9462.74
 		period 3701.14
 
 system Nona
@@ -18091,7 +18091,7 @@ system Nona
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 1080
+	habitable 4159.2
 	link Esix
 	link Gerenus
 	asteroids "large metal" 1 3
@@ -18117,15 +18117,15 @@ system Nona
 		period 10
 	object
 		sprite planet/desert7
-		distance 166.29
+		distance 524.38
 		period 26.1004
 	object
 		sprite planet/desert5-b
-		distance 342.7
+		distance 1165.23
 		period 77.2181
 	object "Siteria"
 		sprite planet/ocean0-b
-		distance 675.34
+		distance 2469.87
 		period 213.615
 		object
 			sprite planet/station3bd
@@ -18133,7 +18133,7 @@ system Nona
 			period 23.9139
 	object
 		sprite planet/gas4
-		distance 2149.35
+		distance 8943.78
 		period 1212.85
 		object
 			sprite planet/dust1
@@ -18145,8 +18145,8 @@ system Nunki
 	government Pirate
 	attributes "south"
 	arrival 1500
-	habitable 214.375
-	belt 1930
+	habitable 693.94
+	belt 7933.31
 	link Albaldah
 	asteroids "small rock" 15 3.3516
 	asteroids "medium rock" 77 1.8144
@@ -18176,7 +18176,7 @@ system Nunki
 		period 10
 	object Albatross
 		sprite planet/cloud8
-		distance 272.14
+		distance 903.11
 		period 122.648
 		object
 			sprite planet/europa-b
@@ -18184,15 +18184,15 @@ system Nunki
 			period 18.0979
 	object
 		sprite planet/ice8
-		distance 639.14
+		distance 2323.5
 		period 441.435
 	object
 		sprite planet/rock2
-		distance 1205.14
+		distance 4698.1
 		period 1142.96
 	object
 		sprite planet/gas17-b
-		distance 2240.14
+		distance 9365.66
 		period 2896.58
 		object
 			sprite planet/dust0
@@ -18216,8 +18216,8 @@ system Oblate
 	government Pirate
 	attributes "core"
 	arrival 1500
-	habitable 12000
-	belt 1704
+	habitable 61097.39
+	belt 6906.24
 	haze _menu/haze-133
 	link Alcyone
 	link Moktar
@@ -18248,7 +18248,7 @@ system Oblate
 		period 10
 	object
 		sprite planet/ice4
-		distance 397.973
+		distance 1374.83
 		period 70.3976
 		object
 			sprite planet/dust0-b
@@ -18256,19 +18256,19 @@ system Oblate
 			period 13.1646
 	object
 		sprite planet/lava2
-		distance 673.733
+		distance 2463.35
 		period 155.063
 	object
 		sprite planet/rock17
-		distance 1201.97
+		distance 4684.36
 		period 369.505
 	object
 		sprite planet/cloud6
-		distance 1560.53
+		distance 6262.32
 		period 546.622
 	object
 		sprite planet/gas0-b
-		distance 4260.49
+		distance 19184.26
 		period 2465.86
 
 system Orbona
@@ -18276,8 +18276,8 @@ system Orbona
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 2859.44
-	belt 1507
+	habitable 12294.03
+	belt 6023.79
 	haze _menu/haze-67
 	link Limen
 	asteroids "small rock" 22 3.99
@@ -18304,16 +18304,16 @@ system Orbona
 	fleet "Human Miners" 1500
 	object
 		sprite star/giant
-		distance 20.2539
+		distance 52.06
 		period 9.71046
 	object
 		sprite star/k0
-		distance 98.7461
+		distance 295.4
 		period 9.71046
 		offset 180
 	object
 		sprite planet/ice6
-		distance 447.836
+		distance 1566.72
 		period 70.8921
 		object
 			sprite planet/desert4
@@ -18321,11 +18321,11 @@ system Orbona
 			period 22.8635
 	object
 		sprite planet/desert3-b
-		distance 862.846
+		distance 3241.46
 		period 189.592
 	object
 		sprite planet/ice1
-		distance 1210.49
+		distance 4721.28
 		period 315.035
 		object
 			sprite planet/rock3-b
@@ -18333,11 +18333,11 @@ system Orbona
 			period 19.7858
 	object
 		sprite planet/ocean1-b
-		distance 1594.3
+		distance 6413.28
 		period 476.182
 	object
 		sprite planet/gas4-b
-		distance 2057.86
+		distance 8520.77
 		period 698.3
 		object
 			sprite planet/dust1
@@ -18349,8 +18349,8 @@ system Orvala
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 533.75
-	belt 1431
+	habitable 1902.86
+	belt 5686.84
 	link "Zeta Aquilae"
 	asteroids "small rock" 27 1.44
 	asteroids "medium rock" 2 2.6304
@@ -18374,16 +18374,16 @@ system Orvala
 	fleet "Large Southern Pirates" 3000
 	object
 		sprite star/k0
-		distance 14.9297
+		distance 37.33
 		period 17.8357
 		offset 180
 	object
 		sprite star/m8
-		distance 87.0703
+		distance 257.23
 		period 17.8357
 	object
 		sprite planet/cloud4-b
-		distance 410.58
+		distance 1423.11
 		period 144.042
 		object
 			sprite planet/dust5-b
@@ -18391,7 +18391,7 @@ system Orvala
 			period 18.0139
 	object
 		sprite planet/rock1
-		distance 995.94
+		distance 3801.17
 		period 544.178
 		object
 			sprite planet/desert4-b
@@ -18399,11 +18399,11 @@ system Orvala
 			period 19.525
 	object
 		sprite planet/rock3
-		distance 1695.94
+		distance 6869.89
 		period 1209.22
 	object
 		sprite planet/gas15-b
-		distance 2258.3
+		distance 9450.29
 		period 1858.08
 		object
 			sprite planet/dust3
@@ -18415,8 +18415,8 @@ system Ossipago
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 1948.28
-	belt 1803
+	habitable 8017.03
+	belt 7354.3
 	haze _menu/haze-red
 	link Antevorta
 	link Nenia
@@ -18443,36 +18443,36 @@ system Ossipago
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/f5-old
-		distance 11.9736
+		distance 29.35
 		period 9.06221
 	object
 		sprite star/m4
-		distance 88.0264
+		distance 260.33
 		period 9.06221
 		offset 180
 	object
 		sprite planet/rock13-b
-		distance 249.516
+		distance 820.55
 		period 35.7176
 	object
 		sprite planet/dust0-b
-		distance 448.756
+		distance 1570.29
 		period 86.149
 	object
 		sprite planet/rock12
-		distance 1044.4
+		distance 4007.16
 		period 305.867
 	object
 		sprite planet/ice4-b
-		distance 1274.65
+		distance 5000.28
 		period 412.4
 	object "Ember Graveyard"
 		sprite planet/wormhole-red
-		distance 3674.15
+		distance 16261.39
 		period 770.273
 	object
 		sprite planet/gas10-b
-		distance 2584.65
+		distance 10984.32
 		period 1944.93
 		object
 			sprite planet/rock17
@@ -18485,7 +18485,7 @@ system "Over the Rainbow"
 	attributes "pleiades"
 	link "Terra Incognita"
 	arrival 1500
-	habitable 1215
+	habitable 4740.84
 	haze _menu/haze-blackbody
 	asteroids "small rock" 1 3.3098
 	asteroids "medium rock" 8 3.3345
@@ -18497,7 +18497,7 @@ system "Over the Rainbow"
 		sprite planet/wormhole
 	object
 		sprite star/k5
-		distance 1455.1
+		distance 5793.47
 		period 875.481048
 		offset 180
 		object
@@ -18506,7 +18506,7 @@ system "Over the Rainbow"
 			period 12.179969
 	object
 		sprite star/g0
-		distance 544.9
+		distance 1946.95
 		period 875.481048
 		object
 			sprite star/m4
@@ -18519,7 +18519,7 @@ system Paeli
 	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 425.92
+	habitable 1482.07
 	link Esix
 	link Polerius
 	asteroids "large metal" 1 4
@@ -18549,16 +18549,16 @@ system Paeli
 		period 10
 	object
 		sprite planet/desert4-b
-		distance 275
+		distance 913.61
 		period 64
 	object
 		sprite planet/cloud3
-		distance 746.89
+		distance 2761.75
 		period 395.622
 		offset 16.1975
 	object
 		sprite planet/desert6-b
-		distance 1213.03
+		distance 4732.3
 		period 818.848
 		offset 125.921
 		object
@@ -18567,7 +18567,7 @@ system Paeli
 			period 15
 	object
 		sprite planet/gas2-b
-		distance 2010.84
+		distance 8304.22
 		period 1747.68
 		offset 270.243
 		object Eavine
@@ -18586,8 +18586,8 @@ system Pantica
 	government Remnant
 	attributes "ember waste"
 	arrival 1500
-	habitable 486.68
-	belt 1203
+	habitable 1717.88
+	belt 4688.82
 	haze _menu/haze-red
 	link Arculus
 	link Cinxia
@@ -18620,15 +18620,15 @@ system Pantica
 		period 10
 	object Capitoline
 		sprite planet/lava1
-		distance 140.44
+		distance 435.3
 		period 30.1769
 	object Aventine
 		sprite planet/ocean0
-		distance 542.45
+		distance 1937.26
 		period 229.075
 	object Esquiline
 		sprite planet/gas9-b
-		distance 1268.21
+		distance 4972.2
 		period 818.889
 		object Quirinal
 			sprite planet/lava0
@@ -18636,7 +18636,7 @@ system Pantica
 			period 14.6443
 	object Servian
 		sprite planet/gas8
-		distance 1879.46
+		distance 7702.34
 		period 1477.37
 
 system Parca
@@ -18644,8 +18644,8 @@ system Parca
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 760
-	belt 1315
+	habitable 2815.59
+	belt 5176.58
 	haze _menu/haze-red
 	link Coluber
 	link Lucina
@@ -18671,20 +18671,20 @@ system Parca
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/g5-old
-		distance 18.2961
+		distance 46.59
 		period 15.1673
 		offset 180
 	object
 		sprite star/m8
-		distance 84.7039
+		distance 249.55
 		period 15.1673
 	object
 		sprite planet/miranda
-		distance 216.344
+		distance 700.98
 		period 46.1711
 	object
 		sprite planet/gas14
-		distance 587.834
+		distance 2117.66
 		period 206.793
 		object
 			sprite planet/rock3
@@ -18692,15 +18692,15 @@ system Parca
 			period 13.1985
 	object
 		sprite planet/desert4-b
-		distance 928.524
+		distance 3516.51
 		period 410.528
 	object
 		sprite planet/browndwarf-y
-		distance 1622.01
+		distance 6537.44
 		period 947.84
 	object
 		sprite planet/gas13
-		distance 3818.85
+		distance 16977.84
 		period 3424.15
 		object
 			sprite planet/rhea
@@ -18720,8 +18720,8 @@ system Peacock
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 214.375
-	belt 1870
+	habitable 693.94
+	belt 7659.19
 	haze _menu/haze-133
 	link Tais
 	link "Kaus Australis"
@@ -18756,11 +18756,11 @@ system Peacock
 		period 10
 	object "New Washington"
 		sprite planet/ocean3
-		distance 196.06
+		distance 628.82
 		period 74.9992
 	object
 		sprite planet/ice2-b
-		distance 683.35
+		distance 2502.38
 		period 488.02
 		object
 			sprite planet/io-b
@@ -18768,15 +18768,15 @@ system Peacock
 			period 18.0979
 	object
 		sprite planet/desert9-b
-		distance 1248.71
+		distance 4887.28
 		period 1205.49
 	object
 		sprite planet/oberon
-		distance 1517.52
+		distance 6070.59
 		period 1615.01
 	object
 		sprite planet/neptune
-		distance 2702.33
+		distance 11543.28
 		period 3837.78
 		object
 			sprite planet/europa-b
@@ -18796,8 +18796,8 @@ system Pelubta
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 9265
-	belt 1709
+	habitable 45729.67
+	belt 6928.79
 	link Meblumem
 	link Gupta
 	link Ablodab
@@ -18830,28 +18830,28 @@ system Pelubta
 	fleet Heliarch 400
 	object
 		sprite star/b5
-		distance 10.9957
+		distance 26.75
 		period 8.64806
 		offset 180
 	object
 		sprite star/g5
-		distance 152.004
+		distance 474.95
 		period 8.64806
 	object
 		sprite planet/rock7
-		distance 331.254
+		distance 1122.27
 		period 25.0541
 	object
 		sprite planet/dust7-b
-		distance 451.254
+		distance 1579.97
 		period 39.8354
 	object
 		sprite planet/lava6-b
-		distance 668.214
+		distance 2440.99
 		period 71.7812
 	object
 		sprite planet/gas6
-		distance 1831.43
+		distance 7483.52
 		period 325.702
 		offset 337.566
 		object "Pelubta Station"
@@ -18861,7 +18861,7 @@ system Pelubta
 			offset 176
 	object
 		sprite planet/gas2-b
-		distance 2309.75
+		distance 9690.49
 		period 461.303
 		object
 			sprite planet/io
@@ -18877,8 +18877,8 @@ system Peragenor
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 1080
-	belt 1920
+	habitable 4159.2
+	belt 7887.55
 	haze _menu/haze-red
 	link Stercutus
 	asteroids "medium rock" 1 2.646
@@ -18906,19 +18906,19 @@ system Peragenor
 		period 10
 	object
 		sprite planet/europa-b
-		distance 170.29
+		distance 538.31
 		period 27.0478
 	object
 		sprite planet/rock4
-		distance 355.18
+		distance 1212.25
 		period 81.4743
 	object
 		sprite planet/desert9
-		distance 952.27
+		distance 3616.51
 		period 357.675
 	object
 		sprite planet/gas1-b
-		distance 1762.56
+		distance 7170.92
 		period 900.666
 		object
 			sprite planet/ice7-b
@@ -18934,7 +18934,7 @@ system Peragenor
 			period 44.1507
 	object "Remnant Wormhole"
 		sprite planet/wormhole-red
-		distance 2300
+		distance 9644.92
 		period 1342.58
 
 system Peresedersi
@@ -18942,8 +18942,8 @@ system Peresedersi
 	government Uninhabited
 	attributes "archon" "korath" "nova"
 	arrival 1500
-	habitable 100
-	belt 1065
+	habitable 299.53
+	belt 4095.07
 	haze _menu/haze-blackbody
 	asteroids "small rock" 49 1.403
 	asteroids "medium rock" 5 2.185
@@ -18970,15 +18970,15 @@ system Peresedersi
 		offset 190
 	object
 		sprite planet/lava5
-		distance 1567.08
+		distance 6291.57
 		period 755.066
 	object
 		sprite planet/lava1
-		distance 1761.08
+		distance 7164.22
 		period 899.532
 	object
 		sprite planet/lava7
-		distance 2248.08
+		distance 9402.65
 		period 1297.38
 
 system Perfica
@@ -18986,8 +18986,8 @@ system Perfica
 	government Uninhabited
 	attributes "ember waste"
 	arrival 1500
-	habitable 1080
-	belt 1160
+	habitable 4159.2
+	belt 4502.93
 	haze _menu/haze-red
 	link Cinxia
 	link Farinus
@@ -19017,23 +19017,23 @@ system Perfica
 		period 10
 	object
 		sprite planet/ice5
-		distance 351
+		distance 1196.48
 		period 94
 	object
 		sprite planet/dust6-b
-		distance 652
+		distance 2375.39
 		period 174
 	object
 		sprite planet/cloud6-b
-		distance 962
+		distance 3657.57
 		period 348
 	object
 		sprite planet/desert4-b
-		distance 1757.75
+		distance 7149.14
 		period 896.982
 	object
 		sprite planet/gas4
-		distance 2712.71
+		distance 11592.73
 		period 1719.7
 
 system Persian
@@ -19041,8 +19041,8 @@ system Persian
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 2170.62
-	belt 1308
+	habitable 9042.43
+	belt 5145.95
 	haze _menu/haze-133
 	link Alnair
 	link Gienah
@@ -19073,16 +19073,16 @@ system Persian
 	fleet "Human Miners" 3000
 	object
 		sprite star/f5-old
-		distance 27.8124
+		distance 73.61
 		period 13.0946
 	object
 		sprite star/k0
-		distance 104.688
+		distance 315.01
 		period 13.0946
 		offset 180
 	object
 		sprite planet/rock13
-		distance 419.028
+		distance 1455.55
 		period 73.643
 		object
 			sprite planet/lava0
@@ -19090,7 +19090,7 @@ system Persian
 			period 17.7001
 	object
 		sprite planet/gas11-b
-		distance 981.718
+		distance 3740.93
 		period 264.087
 		object
 			sprite planet/ice7
@@ -19098,11 +19098,11 @@ system Persian
 			period 12.4717
 	object
 		sprite planet/ocean4
-		distance 1698.08
+		distance 6879.54
 		period 600.764
 	object
 		sprite planet/dust1-b
-		distance 2414.12
+		distance 10179.68
 		period 1018.37
 
 system Persitar
@@ -19110,8 +19110,8 @@ system Persitar
 	government Uninhabited
 	attributes "korath" "nova"
 	arrival 1500
-	habitable 100
-	belt 1948
+	habitable 299.53
+	belt 8015.74
 	haze _menu/haze-blackbody
 	asteroids "small rock" 72 3.348
 	asteroids "medium rock" 2 4.482
@@ -19136,11 +19136,11 @@ system Persitar
 		offset 260
 	object
 		sprite planet/lava1-b
-		distance 480.258
+		distance 1692.8
 		period 190.831
 	object
 		sprite planet/lava5
-		distance 825.017
+		distance 3084.1
 		period 429.667
 
 system Phact
@@ -19148,8 +19148,8 @@ system Phact
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1080.62
-	belt 1704
+	habitable 4161.85
+	belt 6906.24
 	haze _menu/haze-67
 	link Wazn
 	link Canopus
@@ -19181,28 +19181,28 @@ system Phact
 	fleet "Human Miners" 5000
 	object
 		sprite star/g5
-		distance 47.0119
+		distance 130.77
 		period 14.3263
 		offset 180
 	object
 		sprite star/k0
-		distance 64.4881
+		distance 184.96
 		period 14.3263
 	object
 		sprite planet/lava4
-		distance 266.988
+		distance 884.24
 		period 53.0836
 	object
 		sprite planet/ocean6-b
-		distance 559.478
+		distance 2004.75
 		period 161.026
 	object
 		sprite planet/rock8-b
-		distance 858.728
+		distance 3224.29
 		period 306.201
 	object Serpens
 		sprite planet/cloud6
-		distance 1377.17
+		distance 5449.43
 		period 621.875
 		object
 			sprite planet/dust3-b
@@ -19210,11 +19210,11 @@ system Phact
 			period 19.9009
 	object
 		sprite planet/dust4
-		distance 1892.38
+		distance 7761.32
 		period 1001.69
 	object
 		sprite planet/miranda
-		distance 2711.38
+		distance 11586.39
 		period 1717.94
 
 system Phecda
@@ -19222,8 +19222,8 @@ system Phecda
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1375
+	habitable 1080.19
+	belt 5439.88
 	link Algorel
 	link "Tania Australis"
 	link Merak
@@ -19257,23 +19257,23 @@ system Phecda
 		period 10
 	object "New Sahara"
 		sprite planet/forest0
-		distance 173.24
+		distance 548.6
 		period 50.9867
 	object
 		sprite planet/dust2-b
-		distance 410
+		distance 1420.88
 		period 185.635
 	object
 		sprite planet/dust4
-		distance 780.76
+		distance 2901.05
 		period 487.822
 	object
 		sprite planet/rock7
-		distance 1440.85
+		distance 5730.4
 		period 1222.96
 	object
 		sprite planet/rock3
-		distance 4139.54
+		distance 18577.14
 		period 5955.43
 
 system Pherkad
@@ -19281,8 +19281,8 @@ system Pherkad
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 135
-	belt 1924
+	habitable 416.76
+	belt 7905.85
 	haze _menu/haze-67
 	link "Beta Lupi"
 	link "Kappa Centauri"
@@ -19310,19 +19310,19 @@ system Pherkad
 		period 10
 	object Solace
 		sprite planet/forest5-b
-		distance 161.25
+		distance 506.89
 		period 70.4925
 	object
 		sprite planet/rock12-b
-		distance 585.25
+		distance 2107.35
 		period 487.422
 	object
 		sprite planet/rock15-b
-		distance 848.25
+		distance 3180.65
 		period 850.509
 	object
 		sprite planet/gas1-b
-		distance 1543.81
+		distance 6187.71
 		period 2088.26
 		object
 			sprite planet/mercury
@@ -19338,8 +19338,8 @@ system Phurad
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1080
-	belt 1881
+	habitable 4159.2
+	belt 7709.37
 	link Tejat
 	link Canopus
 	link Wazn
@@ -19371,11 +19371,11 @@ system Phurad
 		period 10
 	object
 		sprite planet/rock18-b
-		distance 242.81
+		distance 796.23
 		period 46.0519
 	object Pearl
 		sprite planet/ocean0
-		distance 767.81
+		distance 2847.71
 		period 258.958
 		object
 			sprite planet/dust1
@@ -19383,7 +19383,7 @@ system Phurad
 			period 16.7188
 	object
 		sprite planet/gas17
-		distance 1584.81
+		distance 6370.82
 		period 767.916
 		object
 			sprite planet/ganymede-b
@@ -19391,15 +19391,15 @@ system Phurad
 			period 13.1646
 	object
 		sprite planet/dust3-b
-		distance 2639.02
+		distance 11242.2
 		period 1650.11
 
 system Pik'ro'iyak
 	pos -378.845 -677.001
 	government Wanderer
 	arrival 1500
-	habitable 233.28
-	belt 1279
+	habitable 761.8
+	belt 5019.25
 	haze _menu/haze-none
 	link Si'yak'ku
 	link Ek'kek'ru
@@ -19424,23 +19424,23 @@ system Pik'ro'iyak
 		period 10
 	object "Var' Kayi"
 		sprite planet/forest1-b
-		distance 243.09
+		distance 797.25
 		period 99.2595
 	object
 		sprite planet/desert8
-		distance 484.09
+		distance 1707.76
 		period 278.94
 	object
 		sprite planet/gas2
-		distance 1091.09
+		distance 4206.68
 		period 943.87
 	object
 		sprite planet/cloud3
-		distance 1353.5
+		distance 5345.38
 		period 1304.09
 	object
 		sprite planet/europa-b
-		distance 3272.11
+		distance 14288.82
 		period 4901.88
 
 system Plort
@@ -19448,8 +19448,8 @@ system Plort
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 320
-	belt 1490
+	habitable 1080.19
+	belt 5948.25
 	link "Sol Arach"
 	asteroids "small rock" 7 7.3606
 	asteroids "medium rock" 40 4.5942
@@ -19481,23 +19481,23 @@ system Plort
 		period 10
 	object
 		sprite planet/ice0-b
-		distance 158.84
+		distance 498.55
 		period 44.7636
 	object "Plort's Water"
 		sprite planet/water1
-		distance 343.05
+		distance 1166.55
 		period 142.076
 	object
 		sprite planet/rock2-b
-		distance 791.09
+		distance 2943.67
 		period 497.535
 	object
 		sprite planet/gas10
-		distance 1546.5
+		distance 6199.71
 		period 1359.91
 	object
 		sprite planet/gas2-b
-		distance 2335.71
+		distance 9811.92
 		period 2524.14
 		object
 			sprite planet/callisto-b
@@ -19508,8 +19508,8 @@ system Polaris
 	pos -35 126
 	government Syndicate
 	arrival 1500
-	habitable 320
-	belt 1906
+	habitable 1080.19
+	belt 7823.54
 	haze _menu/haze-133
 	link Achernar
 	asteroids "small rock" 1 7.67
@@ -19539,19 +19539,19 @@ system Polaris
 		period 10
 	object
 		sprite planet/ocean0-b
-		distance 227.44
+		distance 740.77
 		period 76.6982
 	object Shangri-La
 		sprite planet/forest5
-		distance 520.05
+		distance 1848.83
 		period 265.187
 	object
 		sprite planet/cloud0
-		distance 955.81
+		distance 3631.45
 		period 660.758
 	object
 		sprite planet/gas15
-		distance 2199.81
+		distance 9178.0
 		period 2307.08
 		object
 			sprite planet/ice0-b
@@ -19564,7 +19564,7 @@ system Polerius
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 1505.92
+	habitable 6018.99
 	link Paeli
 	asteroids "small rock" 2 4
 	asteroids "medium rock" 8 5
@@ -19590,32 +19590,32 @@ system Polerius
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/g0
-		distance 33.9397
+		distance 91.53
 		period 13.5497
 		offset 180
 	object
 		sprite star/k5-old
-		distance 86.0603
+		distance 253.95
 		period 13.5497
 	object
 		sprite planet/lava7
-		distance 219.9
+		distance 713.71
 		period 33.6123
 	object
 		sprite planet/rock19-b
-		distance 644.74
+		distance 2346.08
 		period 168.747
 	object "Celeatis"
 		sprite planet/rock10-b
-		distance 1091.15
+		distance 4206.93
 		period 371.523
 	object "Ember Graveyard"
 		sprite planet/wormhole-red
-		distance 1774.15
+		distance 7223.43
 		period 770.273
 	object
 		sprite planet/gas14-b
-		distance 2398.24
+		distance 10105.08
 		period 1210.59
 		object Ceilia'sei
 			sprite planet/station3b
@@ -19631,8 +19631,8 @@ system Pollux
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1080
-	belt 1161
+	habitable 4159.2
+	belt 4507.24
 	haze _menu/haze-67
 	link Procyon
 	link Castor
@@ -19663,23 +19663,23 @@ system Pollux
 		period 10
 	object
 		sprite planet/ice4-b
-		distance 160.64
+		distance 504.78
 		period 24.7816
 	object
 		sprite planet/ocean8-b
-		distance 608.85
+		distance 2201.74
 		period 182.858
 	object Thrall
 		sprite planet/forest6
-		distance 895.89
+		distance 3379.55
 		period 326.385
 	object Martini
 		sprite planet/ocean4
-		distance 1248.33
+		distance 4885.63
 		period 536.837
 	object
 		sprite planet/gas7-b
-		distance 4171.54
+		distance 18737.56
 		period 3279.39
 
 system Porrima
@@ -19687,8 +19687,8 @@ system Porrima
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 760
-	belt 1636
+	habitable 2815.59
+	belt 6600.22
 	haze _menu/haze-67
 	link Muphrid
 	link Merak
@@ -19719,24 +19719,24 @@ system Porrima
 	fleet "Small Southern Pirates" 6000
 	object
 		sprite star/g5
-		distance 21.1382
+		distance 54.54
 		period 18.8353
 		offset 180
 	object
 		sprite star/m4
-		distance 97.8618
+		distance 292.49
 		period 18.8353
 	object
 		sprite planet/gas9-b
-		distance 392.272
+		distance 1353.06
 		period 112.729
 	object
 		sprite planet/lava2-b
-		distance 723.282
+		distance 2665.08
 		period 282.237
 	object "New Switzerland"
 		sprite planet/ocean4
-		distance 1128.64
+		distance 4367.85
 		period 550.158
 		object
 			sprite planet/rock3
@@ -19744,7 +19744,7 @@ system Porrima
 			period 19.0302
 	object
 		sprite planet/gas6-b
-		distance 2851.64
+		distance 12256.64
 		period 2209.51
 		object
 			sprite planet/dust0
@@ -19757,7 +19757,7 @@ system Postverta
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	arrival 1500
-	habitable 135
+	habitable 416.76
 	haze _menu/haze-red
 	asteroids "medium rock" 4 2
 	asteroids "large rock" 4 3
@@ -19770,11 +19770,11 @@ system Postverta
 		period 19
 	object
 		sprite planet/desert7
-		distance 439
+		distance 1532.54
 		period 143
 	object
 		sprite planet/fog0
-		distance 814
+		distance 3038.43
 		period 362
 		object
 			sprite planet/dust4
@@ -19782,19 +19782,19 @@ system Postverta
 			period 21
 	object
 		sprite planet/rock10
-		distance 1208
+		distance 4710.49
 		period 654
 	object "Ssil Vida"
 		sprite planet/sheragi_postverta
-		distance 1408
+		distance 5585.27
 		period 554
 	
 system Prakacha'a
 	pos -35.1114 -802.607
 	government Wanderer
 	arrival 1500
-	habitable 1505.92
-	belt 1637
+	habitable 6018.99
+	belt 6604.71
 	haze _menu/haze-33
 	link Chy'chra
 	link Ik'kara'ka
@@ -19824,32 +19824,32 @@ system Prakacha'a
 	fleet "Unfettered Raid" 5000
 	object
 		sprite star/g0
-		distance 32.5255
+		distance 87.36
 		period 12.7118
 		offset 180
 	object
 		sprite star/k5-old
-		distance 82.4745
+		distance 242.34
 		period 12.7118
 	object
 		sprite planet/rock18
-		distance 247.965
+		distance 814.92
 		period 40.2479
 	object
 		sprite planet/desert5-b
-		distance 458.205
+		distance 1606.94
 		period 101.099
 	object
 		sprite planet/rock19-b
-		distance 692.455
+		distance 2539.38
 		period 187.822
 	object
 		sprite planet/tethys
-		distance 846.065
+		distance 3171.55
 		period 253.667
 	object
 		sprite planet/gas6-b
-		distance 4036.31
+		distance 18060.64
 		period 2643.24
 		object
 			sprite planet/callisto-b
@@ -19873,8 +19873,8 @@ system Procyon
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 455.625
-	belt 1763
+	habitable 1596.92
+	belt 7172.91
 	haze _menu/haze-67
 	link Sirius
 	link Pollux
@@ -19908,23 +19908,23 @@ system Procyon
 		period 10
 	object
 		sprite planet/rock4
-		distance 243.06
+		distance 797.14
 		period 71.0111
 	object
 		sprite planet/cloud4
-		distance 623.31
+		distance 2259.79
 		period 291.617
 	object
 		sprite planet/mars
-		distance 1201.15
+		distance 4680.81
 		period 780.103
 	object
 		sprite planet/ice4
-		distance 1558.96
+		distance 6255.31
 		period 1153.48
 	object
 		sprite planet/dust3-b
-		distance 3148.97
+		distance 13690.26
 		period 3311.38
 
 system Prosa
@@ -19932,7 +19932,7 @@ system Prosa
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	arrival 1500
-	habitable 2372.76
+	habitable 9985.52
 	haze _menu/haze-red
 	link Vaticanus
 	asteroids "medium metal" 11 2
@@ -19949,19 +19949,19 @@ system Prosa
 		period 7
 	object
 		sprite planet/cloud1
-		distance 311
+		distance 1046.66
 		period 34
 	object
 		sprite planet/desert9
-		distance 749
+		distance 2770.41
 		period 127
 	object
 		sprite planet/rock6
-		distance 941
+		distance 3569.02
 		period 179
 	object
 		sprite planet/gas17
-		distance 1311
+		distance 5159.07
 		period 695
 		object
 			sprite planet/callisto
@@ -19976,8 +19976,8 @@ system "Pug Iyik"
 	pos -361.149 -883.233
 	government "Pug (Wanderer)"
 	arrival 1500
-	habitable 625
-	belt 1286
+	habitable 2266.58
+	belt 5049.8
 	haze _menu/haze-blackbody
 	asteroids "small rock" 35 7.6356
 	asteroids "medium rock" 5 6.9552
@@ -20003,7 +20003,7 @@ system "Pug Iyik"
 		period 10
 	object
 		sprite planet/rock6-b
-		distance 268.89
+		distance 891.21
 		period 70.5476
 		object
 			sprite planet/europa
@@ -20011,15 +20011,15 @@ system "Pug Iyik"
 			period 25.4415
 	object "Vara Pug"
 		sprite planet/ocean4
-		distance 643.85
+		distance 2342.49
 		period 261.395
 	object
 		sprite planet/lava3-b
-		distance 1271.1
+		distance 4984.8
 		period 725.086
 	object
 		sprite planet/gas15
-		distance 2701.19
+		distance 11537.86
 		period 2246.22
 		object
 			sprite planet/dust5
@@ -20035,8 +20035,8 @@ system Quaru
 	government Heliarch
 	attributes "ringworld"
 	arrival 1500
-	habitable 700
-	belt 1440
+	habitable 2570.09
+	belt 5726.64
 	haze _menu/haze-133
 	link "Ki War Ek"
 	link Ekuarik
@@ -20065,261 +20065,261 @@ system Quaru
 		period 10
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 20
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 40
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 60
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 80
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 100
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 120
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 140
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 160
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 220
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 240
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 260
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 280
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 300
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 320
 	object "Ring of Friendship"
 		sprite planet/ringworld
-		distance 812
+		distance 3030.14
 		period 360
 		offset 340
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 21
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 32
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 44
 	object
 		sprite planet/panels3
-		distance 800
+		distance 2980.49
 		period 360
 		offset 53
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 62
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 66
 	object
 		sprite planet/panels4
-		distance 800
+		distance 2980.49
 		period 360
 		offset 73
 	object
 		sprite planet/panels5
-		distance 800
+		distance 2980.49
 		period 360
 		offset 87
 	object
 		sprite planet/panels3
-		distance 800
+		distance 2980.49
 		period 360
 		offset 95
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 104
 	object
 		sprite planet/panels4
-		distance 800
+		distance 2980.49
 		period 360
 		offset 116
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 125
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 134
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 149
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 29
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 38
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 42
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 55
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 64
 	object
 		sprite planet/panels5
-		distance 830
+		distance 3104.78
 		period 360
 		offset 78
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 92
 	object
 		sprite planet/panels5
-		distance 830
+		distance 3104.78
 		period 360
 		offset 106
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 120
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 132
 	object
 		sprite planet/panels1
-		distance 830
+		distance 3104.78
 		period 360
 		offset 145
 	object
 		sprite planet/panels1
-		distance 800
+		distance 2980.49
 		period 360
 		offset 185
 	object
 		sprite planet/panels3
-		distance 800
+		distance 2980.49
 		period 360
 		offset 197
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 207
 	object
 		sprite planet/panels5
-		distance 800
+		distance 2980.49
 		period 360
 		offset 218
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 231
 	object
 		sprite planet/panels2
-		distance 800
+		distance 2980.49
 		period 360
 		offset 244
 	object
 		sprite planet/panels2
-		distance 830
+		distance 3104.78
 		period 360
 		offset 198
 	object
 		sprite planet/panels3
-		distance 830
+		distance 3104.78
 		period 360
 		offset 212
 	object
 		sprite planet/panels4
-		distance 830
+		distance 3104.78
 		period 360
 		offset 237
 
@@ -20329,7 +20329,7 @@ system Queri
 	attributes "ember waste" "graveyard"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 135
+	habitable 416.76
 	link Esix
 	link Ritilas
 	trade Clothing 292
@@ -20355,8 +20355,8 @@ system Rajak
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 78.125
-	belt 1410
+	habitable 228.34
+	belt 5594.1
 	haze _menu/haze-67
 	link Sumar
 	link Hassaleh
@@ -20384,15 +20384,15 @@ system Rajak
 		period 10
 	object
 		sprite planet/rock5
-		distance 130.39
+		distance 401.12
 		period 67.3801
 	object
 		sprite planet/cloud3-b
-		distance 565.64
+		distance 2029.24
 		period 608.801
 	object
 		sprite planet/gas4
-		distance 1331.89
+		distance 5250.56
 		period 2199.72
 		object
 			sprite planet/desert4
@@ -20408,7 +20408,7 @@ system Rajak
 			period 30.0422
 	object
 		sprite planet/gas10
-		distance 2450.13
+		distance 10349.05
 		period 5488.44
 		object
 			sprite planet/dust3
@@ -20424,8 +20424,8 @@ system Rasalhague
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 455.625
-	belt 1282
+	habitable 1596.92
+	belt 5032.35
 	haze _menu/haze-133
 	link "Zeta Aquilae"
 	link Cebalrai
@@ -20458,15 +20458,15 @@ system Rasalhague
 		period 10
 	object
 		sprite planet/lava5-b
-		distance 245.51
+		distance 806.02
 		period 72.0875
 	object Oblivion
 		sprite planet/ocean5
-		distance 477.47
+		distance 1681.92
 		period 195.513
 	object
 		sprite planet/gas3
-		distance 1097.83
+		distance 4235.56
 		period 681.646
 		object
 			sprite planet/rock0
@@ -20474,11 +20474,11 @@ system Rasalhague
 			period 11.0929
 	object
 		sprite planet/rock17
-		distance 1746.39
+		distance 7097.73
 		period 1367.63
 	object
 		sprite planet/dust0-b
-		distance 2274.48
+		distance 9525.76
 		period 2032.73
 
 system Rastaban
@@ -20486,8 +20486,8 @@ system Rastaban
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1080
-	belt 1041
+	habitable 4159.2
+	belt 3992.67
 	haze _menu/haze-133
 	link Girtab
 	link Lesath
@@ -20520,15 +20520,15 @@ system Rastaban
 		period 10
 	object
 		sprite planet/ice6-b
-		distance 177.64
+		distance 563.98
 		period 28.8177
 	object
 		sprite planet/dust6
-		distance 398.4
+		distance 1376.46
 		period 96.7892
 	object Dancer
 		sprite planet/ocean6
-		distance 933.4
+		distance 3537.02
 		period 347.096
 		object
 			sprite planet/ice7
@@ -20536,19 +20536,19 @@ system Rastaban
 			period 20.1893
 	object
 		sprite planet/gas1
-		distance 1677.16
+		distance 6785.28
 		period 836.007
 	object
 		sprite planet/tethys-b
-		distance 3881.4
+		distance 17288.56
 		period 2943.27
 
 system "Rati Cal"
 	pos -116.765 -391.123
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1538
+	habitable 1482.07
+	belt 6161.81
 	link "Due Yoot"
 	link "Lom Tahr"
 	asteroids "small rock" 2 2.967
@@ -20578,15 +20578,15 @@ system "Rati Cal"
 		period 10
 	object
 		sprite planet/ice0-b
-		distance 193.64
+		distance 620.26
 		period 52.2262
 	object Dustmaker
 		sprite planet/rock15
-		distance 341.05
+		distance 1159.03
 		period 122.074
 	object
 		sprite planet/gas7
-		distance 804.29
+		distance 2998.23
 		period 442.094
 		object
 			sprite planet/dust1-b
@@ -20594,7 +20594,7 @@ system "Rati Cal"
 			period 15.6949
 	object
 		sprite planet/gas5
-		distance 2194.1
+		distance 9151.47
 		period 1991.96
 
 system Regor
@@ -20602,8 +20602,8 @@ system Regor
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 455.625
-	belt 1305
+	habitable 1596.92
+	belt 5132.83
 	haze _menu/haze-67
 	link Aspidiske
 	link Naos
@@ -20630,19 +20630,19 @@ system Regor
 		period 10
 	object
 		sprite planet/rock4-b
-		distance 248.19
+		distance 815.74
 		period 73.2711
 	object Windblain
 		sprite planet/ocean7
-		distance 519.08
+		distance 1845.01
 		period 221.619
 	object
 		sprite planet/luna
-		distance 890.64
+		distance 3357.57
 		period 498.092
 	object
 		sprite planet/gas13
-		distance 2209.28
+		distance 9222.03
 		period 1945.95
 		object
 			sprite planet/europa
@@ -20666,8 +20666,8 @@ system Regulus
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 8640
-	belt 1605
+	habitable 42290.44
+	belt 6461.2
 	haze _menu/haze-67
 	link Merak
 	asteroids "small rock" 31 3.7752
@@ -20698,7 +20698,7 @@ system Regulus
 		period 10
 	object
 		sprite planet/gas15-b
-		distance 774.96
+		distance 2877.15
 		period 92.8372
 		object
 			sprite planet/rock3
@@ -20718,11 +20718,11 @@ system Regulus
 			period 69.5635
 	object
 		sprite planet/dust7-b
-		distance 1570.21
+		distance 6305.55
 		period 267.756
 	object
 		sprite planet/gas11
-		distance 2327.7
+		distance 9774.44
 		period 483.274
 		object
 			sprite planet/miranda
@@ -20739,7 +20739,7 @@ system Relifer
 	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 625
+	habitable 2266.58
 	link Feraticus
 	asteroids "large metal" 2 3
 	asteroids "large rock" 1 2
@@ -20768,12 +20768,12 @@ system Relifer
 		period 10
 	object
 		sprite planet/mercury
-		distance 167.69
+		distance 529.25
 		period 34.7441
 		offset 339.439
 	object
 		sprite planet/cloud0-b
-		distance 467.7
+		distance 1643.85
 		period 161.834
 		offset 195.125
 		object
@@ -20782,22 +20782,22 @@ system Relifer
 			period 17.3734
 	object
 		sprite planet/ice3
-		distance 781.79
+		distance 2905.3
 		period 349.748
 		offset 99.1324
 	object
 		sprite planet/water1
-		distance 1126.04
+		distance 4356.67
 		period 604.576
 		offset 252.049
 	object
 		sprite planet/ice1
-		distance 1804.04
+		distance 7359.03
 		period 1226
 		offset 348.55
 	object
 		sprite planet/gas11-b
-		distance 2539.85
+		distance 10772.3
 		period 2048.01
 		offset 144.237
 		object
@@ -20814,7 +20814,7 @@ system Relifer
 			period 40.0477
 	object "Graveyard Wormhole (Unstable)"
 		sprite planet/wormhole-red
-		distance 3462.04
+		distance 15217.29
 		period 894.456
 		offset 114.016
 
@@ -20823,8 +20823,8 @@ system Remembrance
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 486.68
-	belt 1536
+	habitable 1717.88
+	belt 6152.89
 	link Beginning
 	link "Dark Hills"
 	asteroids "small rock" 12 1.716
@@ -20857,19 +20857,19 @@ system Remembrance
 		period 10
 	object
 		sprite planet/desert9-b
-		distance 155.81
+		distance 488.08
 		period 35.264
 	object
 		sprite planet/desert7-b
-		distance 335.82
+		distance 1139.39
 		period 111.583
 	object "Deep Water"
 		sprite planet/water0
-		distance 506.82
+		distance 1796.8
 		period 206.88
 	object
 		sprite planet/gas0-b
-		distance 2021.82
+		distance 8354.74
 		period 1648.36
 		object
 			sprite planet/callisto-b
@@ -20881,8 +20881,8 @@ system Rigel
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1080
-	belt 1782
+	habitable 4159.2
+	belt 7259.01
 	link Saiph
 	link Alnitak
 	link Betelgeuse
@@ -20919,7 +20919,7 @@ system Rigel
 		period 10
 	object
 		sprite planet/cloud7
-		distance 346
+		distance 1177.64
 		period 78.3362
 		object
 			sprite planet/lava1
@@ -20927,7 +20927,7 @@ system Rigel
 			period 18.6328
 	object
 		sprite planet/jupiter
-		distance 998.16
+		distance 3810.58
 		period 383.838
 		object
 			sprite planet/dust5
@@ -20935,7 +20935,7 @@ system Rigel
 			period 11.4109
 	object
 		sprite planet/cloud8-b
-		distance 1600.16
+		distance 6439.52
 		period 779.1
 		object
 			sprite planet/desert4-b
@@ -20943,7 +20943,7 @@ system Rigel
 			period 20.1302
 	object
 		sprite planet/gas5
-		distance 2867
+		distance 12330.28
 		period 1868.49
 		object
 			sprite planet/dust0-b
@@ -20960,7 +20960,7 @@ system Ritilas
 	attributes "ember waste" "graveyard" "wormhole"
 	haze _menu/haze-red
 	arrival 1500
-	habitable 135
+	habitable 416.76
 	link Queri
 	asteroids "large metal" 4 4
 	asteroids "large rock" 18 2
@@ -20988,11 +20988,11 @@ system Ritilas
 		period 10
 	object
 		sprite planet/rock14
-		distance 127
+		distance 389.65
 		period 49.2718
 	object
 		sprite planet/gas0
-		distance 666
+		distance 2432.02
 		period 591.704
 		object
 			sprite planet/callisto
@@ -21004,21 +21004,21 @@ system Ritilas
 			period 24.6864
 	object
 		sprite planet/rock7
-		distance 1205.21
+		distance 4698.4
 		period 1440.41
 	object "Graveyard Wormhole (Stable)"
 		sprite planet/wormhole
-		distance 1641.32
+		distance 6624.11
 		period 2289.21
 		offset 109.88
 	object
 		sprite planet/gas6
-		distance 2296.1
+		distance 9626.7
 		period 3787.73
 		offset 73.9578
 	object
 		sprite planet/gas9
-		distance 4038.51
+		distance 18071.63
 		period 8835.37
 		offset 15.7954
 		object
@@ -21035,8 +21035,8 @@ system Ruchbah
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 2560
-	belt 1598
+	habitable 10867.61
+	belt 6429.85
 	haze _menu/haze-133
 	link Ankaa
 	link Alpheratz
@@ -21072,7 +21072,7 @@ system Ruchbah
 		period 10
 	object
 		sprite planet/cloud2
-		distance 299.25
+		distance 1003.03
 		period 40.9252
 		object
 			sprite planet/europa
@@ -21080,19 +21080,19 @@ system Ruchbah
 			period 13.1134
 	object
 		sprite planet/ice7
-		distance 612.86
+		distance 2217.82
 		period 119.945
 	object
 		sprite planet/ice0
-		distance 942.55
+		distance 3575.55
 		period 228.769
 	object
 		sprite planet/oberon-b
-		distance 1246.16
+		distance 4876.19
 		period 347.777
 	object Crossroads
 		sprite planet/cloud4
-		distance 1794.6
+		distance 7316.17
 		period 601.024
 		object
 			sprite planet/io
@@ -21100,7 +21100,7 @@ system Ruchbah
 			period 16.0379
 	object
 		sprite planet/desert4-b
-		distance 7872.6
+		distance 38109.41
 		period 5522.27
 
 system Rutilicus
@@ -21108,8 +21108,8 @@ system Rutilicus
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 625
-	belt 1771
+	habitable 2266.58
+	belt 7209.15
 	link Arcturus
 	link Cebalrai
 	link Menkent
@@ -21142,19 +21142,19 @@ system Rutilicus
 		period 10
 	object
 		sprite planet/rock6
-		distance 158.61
+		distance 497.75
 		period 31.9607
 	object "New Boston"
 		sprite planet/cloud6
-		distance 513.86
+		distance 1824.46
 		period 186.375
 	object
 		sprite planet/rock13-b
-		distance 864.75
+		distance 3249.4
 		period 406.87
 	object
 		sprite planet/gas14
-		distance 1503.91
+		distance 6010.05
 		period 933.153
 		object
 			sprite planet/ice7-b
@@ -21162,7 +21162,7 @@ system Rutilicus
 			period 15.1366
 	object
 		sprite planet/gas16-b
-		distance 2597.32
+		distance 11044.35
 		period 2117.91
 		object
 			sprite planet/ganymede
@@ -21178,8 +21178,8 @@ system Sabik
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 625
-	belt 1609
+	habitable 2266.58
+	belt 6479.12
 	link Unukalhai
 	link Zubenelgenubi
 	link Kornephoros
@@ -21211,19 +21211,19 @@ system Sabik
 		period 10
 	object
 		sprite planet/cloud2
-		distance 182.25
+		distance 580.14
 		period 39.366
 	object Longjump
 		sprite planet/forest6-b
-		distance 647.5
+		distance 2357.22
 		period 263.621
 	object
 		sprite planet/gas4-b
-		distance 1280.19
+		distance 5024.45
 		period 732.878
 	object
 		sprite planet/gas11-b
-		distance 2061.55
+		distance 8537.79
 		period 1497.65
 
 system Sabriset
@@ -21231,8 +21231,8 @@ system Sabriset
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 1566.68
-	belt 1025
+	habitable 6289.78
+	belt 3924.56
 	link Sepriaptu
 	link Kaliptari
 	asteroids "small rock" 3 3.9285
@@ -21256,29 +21256,29 @@ system Sabriset
 	fleet "Large Quarg" 4000
 	object
 		sprite star/g0
-		distance 35.1028
+		distance 94.96
 		period 12.1391
 	object
 		sprite star/k0
-		distance 77.8972
+		distance 227.61
 		period 12.1391
 		offset 180
 	object
 		sprite planet/gas7-hot
-		distance 279.387
+		distance 929.72
 		period 47.1932
 	object
 		sprite planet/lava7
-		distance 738.015
+		distance 2725.37
 		period 202.613
 		offset 212.423
 	object
 		sprite planet/desert2
-		distance 1012.78
+		distance 3872.62
 		period 325.718
 	object
 		sprite planet/rock5
-		distance 1367.84
+		distance 5408.39
 		period 511.237
 
 system Sadalmelik
@@ -21286,8 +21286,8 @@ system Sadalmelik
 	government Quarg
 	attributes "south"
 	arrival 1500
-	habitable 1715
-	belt 1273
+	habitable 6955.87
+	belt 4993.08
 	link Enif
 	link Sadalsuud
 	asteroids "small rock" 1 3.38
@@ -21315,23 +21315,23 @@ system Sadalmelik
 		period 10
 	object
 		sprite planet/callisto
-		distance 138.24
+		distance 427.79
 		period 15.6992
 	object
 		sprite planet/ganymede-b
-		distance 500.49
+		distance 1771.96
 		period 108.149
 	object
 		sprite planet/cloud4-b
-		distance 836.45
+		distance 3131.57
 		period 233.662
 	object Humanika
 		sprite planet/ocean7
-		distance 1298.94
+		distance 5106.33
 		period 452.18
 	object
 		sprite planet/uranus-b
-		distance 1947.35
+		distance 8012.77
 		period 830.03
 		object Grakhord
 			sprite planet/ice7
@@ -21343,8 +21343,8 @@ system Sadalsuud
 	government Quarg
 	attributes "south"
 	arrival 1500
-	habitable 1400
-	belt 1859
+	habitable 5549.99
+	belt 7609.05
 	link Enif
 	link Sadalmelik
 	asteroids "small rock" 1 4.116
@@ -21365,24 +21365,24 @@ system Sadalsuud
 	fleet Quarg 1000
 	object
 		sprite star/g0
-		distance 26.9714
+		distance 71.18
 		period 13.7031
 	object
 		sprite star/k5
-		distance 91.0286
+		distance 270.11
 		period 13.7031
 		offset 180
 	object
 		sprite planet/ice3-b
-		distance 307.989
+		distance 1035.46
 		period 57.7827
 	object
 		sprite planet/lava2
-		distance 583.399
+		distance 2099.96
 		period 150.641
 	object
 		sprite planet/cloud0-b
-		distance 1021.4
+		distance 3909.25
 		period 348.971
 		object
 			sprite planet/ice8-b
@@ -21390,7 +21390,7 @@ system Sadalsuud
 			period 17.1091
 	object
 		sprite planet/jupiter
-		distance 1668.01
+		distance 6744.09
 		period 728.272
 		object Forpelog
 			sprite planet/rock17
@@ -21398,7 +21398,7 @@ system Sadalsuud
 			period 13.0929
 	object
 		sprite planet/rock7
-		distance 4591.9
+		distance 20858.29
 		period 3326.48
 
 system Sadr
@@ -21406,8 +21406,8 @@ system Sadr
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 3859.38
-	belt 1388
+	habitable 17179.1
+	belt 5497.11
 	link Albireo
 	asteroids "small rock" 48 4.9932
 	asteroids "medium rock" 19 4.5828
@@ -21435,24 +21435,24 @@ system Sadr
 	fleet "Human Miners" 2000
 	object
 		sprite star/a5
-		distance 5.86016
+		distance 13.5
 		period 6.97718
 	object
 		sprite star/m0
-		distance 99.6398
+		distance 298.34
 		period 6.97718
 		offset 180
 	object
 		sprite planet/callisto
-		distance 280.83
+		distance 935.03
 		period 30.3017
 	object
 		sprite planet/rock3-b
-		distance 543.84
+		distance 1942.76
 		period 81.6597
 	object
 		sprite planet/desert6-b
-		distance 876.65
+		distance 3299.07
 		period 167.125
 		object
 			sprite planet/rock17-b
@@ -21460,17 +21460,17 @@ system Sadr
 			period 17.5682
 	object
 		sprite planet/desert5
-		distance 1311.09
+		distance 5159.46
 		period 305.668
 	object
 		sprite planet/miranda
-		distance 2553.34
+		distance 10836.1
 		period 830.739
 
 system "Sagittarius A*"
 	pos 112 22
 	government Uninhabited
-	habitable 10000
+	habitable 49810.72
 	haze _menu/haze-full
 	arrival 2000
 	hazard "Black Hole Gravity" 1
@@ -21488,8 +21488,8 @@ system Saiph
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 320
-	belt 1690
+	habitable 1080.19
+	belt 6843.11
 	haze _menu/haze-33
 	link Rigel
 	link Alnitak
@@ -21519,23 +21519,23 @@ system Saiph
 		period 10
 	object
 		sprite planet/cloud3
-		distance 168.69
+		distance 532.73
 		period 48.9913
 	object Skillet
 		sprite planet/rock12
-		distance 574.94
+		distance 2066.24
 		period 308.261
 	object
 		sprite planet/rock5
-		distance 919.38
+		distance 3478.08
 		period 623.344
 	object
 		sprite planet/tethys
-		distance 1191.38
+		distance 4638.51
 		period 919.518
 	object
 		sprite planet/dust3-b
-		distance 3121.39
+		distance 13556.58
 		period 3899.48
 
 system Salipastart
@@ -21543,8 +21543,8 @@ system Salipastart
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1056
+	habitable 1717.88
+	belt 4056.64
 	haze _menu/haze-133
 	link Similisti
 	link Faronektu
@@ -21575,15 +21575,15 @@ system Salipastart
 		period 10
 	object
 		sprite planet/titan
-		distance 161.81
+		distance 508.83
 		period 37.3204
 	object
 		sprite planet/rhea-b
-		distance 475.22
+		distance 1673.14
 		period 187.837
 	object
 		sprite planet/gas2
-		distance 953.154
+		distance 3620.24
 		period 533.56
 		object
 			sprite planet/station3kd
@@ -21591,11 +21591,11 @@ system Salipastart
 			period 18.3399
 	object
 		sprite planet/europa-b
-		distance 1444.09
+		distance 5744.73
 		period 995.014
 	object
 		sprite planet/uranus
-		distance 2249.1
+		distance 9407.4
 		period 1933.98
 		object
 			sprite planet/tethys-b
@@ -21611,8 +21611,8 @@ system Saquergen
 	government Uninhabited
 	attributes "nova"
 	arrival 1500
-	habitable 100
-	belt 1435
+	habitable 299.53
+	belt 5704.53
 	asteroids "small rock" 3 3.9105
 	asteroids "medium rock" 1 4.3255
 	asteroids "small metal" 2 6.7143
@@ -21633,7 +21633,7 @@ system Saquergen
 		period 1000
 	object
 		sprite planet/lava2
-		distance 938.342
+		distance 3557.82
 		period 531.634
 
 system Sargas
@@ -21641,8 +21641,8 @@ system Sargas
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 911.25
-	belt 1642
+	habitable 3443.95
+	belt 6627.16
 	link Kornephoros
 	link Lesath
 	asteroids "large metal" 1 2.6656
@@ -21664,28 +21664,28 @@ system Sargas
 	fleet "Large Militia" 7000
 	object
 		sprite star/k0
-		distance 53
+		distance 149.14
 		period 14.4611
 		offset 180
 	object
 		sprite star/k0
-		distance 53
+		distance 149.14
 		period 14.4611
 	object
 		sprite planet/rock16
-		distance 327.94
+		distance 1109.86
 		period 78.6924
 	object
 		sprite planet/lava7
-		distance 677.5
+		distance 2478.63
 		period 233.671
 	object Trinket
 		sprite planet/ocean7
-		distance 943.5
+		distance 3579.55
 		period 384.02
 	object
 		sprite planet/oberon
-		distance 2055.94
+		distance 8511.92
 		period 1235.26
 
 system Sarin
@@ -21693,8 +21693,8 @@ system Sarin
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1752
+	habitable 4159.2
+	belt 7123.11
 	link Vindemiatrix
 	asteroids "large metal" 1 1.74
 	trade Clothing 305
@@ -21716,19 +21716,19 @@ system Sarin
 		period 10
 	object
 		sprite planet/desert6
-		distance 216.24
+		distance 700.61
 		period 38.7037
 	object
 		sprite planet/lava6
-		distance 484.8
+		distance 1710.54
 		period 129.925
 	object "Big Sky"
 		sprite planet/forest6-b
-		distance 783.64
+		distance 2912.93
 		period 267.007
 	object
 		sprite planet/venus-b
-		distance 1331.85
+		distance 5250.38
 		period 591.604
 		object
 			sprite planet/rock0
@@ -21736,7 +21736,7 @@ system Sarin
 			period 17.6303
 	object
 		sprite planet/dust4-b
-		distance 3371.1
+		distance 14771.95
 		period 2382.35
 
 system Sayaiban
@@ -21744,8 +21744,8 @@ system Sayaiban
 	government Drak
 	attributes "archon" "korath"
 	arrival 1500
-	habitable 2035
-	belt 1803
+	habitable 8415.42
+	belt 7354.3
 	asteroids "small rock" 13 2.106
 	asteroids "medium rock" 61 1.836
 	asteroids "large rock" 39 2.754
@@ -21768,19 +21768,19 @@ system Sayaiban
 	fleet Nanobots 100
 	object
 		sprite star/f5-old
-		distance 19.1843
+		distance 49.06
 		period 11.9486
 	object
 		sprite star/m0
-		distance 102.816
+		distance 308.82
 		period 11.9486
 	object
 		sprite planet/lava6-b
-		distance 371.702
+		distance 1274.78
 		period 63.5434
 	object
 		sprite planet/desert8
-		distance 791.208
+		distance 2944.16
 		period 197.339
 		object
 			sprite planet/rock7
@@ -21788,11 +21788,11 @@ system Sayaiban
 			period 18.5747
 	object
 		sprite planet/lava3
-		distance 1550.01
+		distance 6215.36
 		period 541.102
 	object
 		sprite planet/rock6
-		distance 1890.51
+		distance 7752.78
 		period 728.865
 
 system Scheat
@@ -21800,8 +21800,8 @@ system Scheat
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1536
+	habitable 2266.58
+	belt 6152.89
 	haze _menu/haze-133
 	link Markab
 	link "Delta Capricorni"
@@ -21831,15 +21831,15 @@ system Scheat
 		period 10
 	object
 		sprite planet/desert10
-		distance 212.61
+		distance 687.64
 		period 49.6016
 	object Delve
 		sprite planet/ice2
-		distance 559.62
+		distance 2005.32
 		period 211.817
 	object
 		sprite planet/cloud1
-		distance 1194.87
+		distance 4653.62
 		period 660.847
 		object
 			sprite planet/dust0-b
@@ -21847,7 +21847,7 @@ system Scheat
 			period 17.2679
 	object
 		sprite planet/gas0
-		distance 2229.12
+		distance 9314.34
 		period 1683.91
 		object "Charybdis Station"
 			sprite planet/station17
@@ -21859,8 +21859,8 @@ system Schedar
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 1080
-	belt 1903
+	habitable 4159.2
+	belt 7809.83
 	haze _menu/haze-133
 	link Mirach
 	link Achernar
@@ -21893,27 +21893,27 @@ system Schedar
 		period 10
 	object
 		sprite planet/lava7
-		distance 146
+		distance 454.32
 		period 21.4722
 	object
 		sprite planet/dust0
-		distance 317.96
+		distance 1072.58
 		period 69.0092
 	object
 		sprite planet/forest0
-		distance 572.21
+		distance 2055.37
 		period 166.602
 	object Amazon
 		sprite planet/cloud1
-		distance 951.97
+		distance 3615.25
 		period 357.506
 	object
 		sprite planet/rock3
-		distance 1589.22
+		distance 6390.55
 		period 771.124
 	object
 		sprite planet/gas10
-		distance 6882.98
+		distance 32791.52
 		period 6950.45
 		object
 			sprite planet/dust5
@@ -21929,8 +21929,8 @@ system Segesta
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 425.92
-	belt 1120
+	habitable 1482.07
+	belt 4330.71
 	haze _menu/haze-red
 	link Stercutus
 	asteroids "small rock" 6 1.9116
@@ -21961,7 +21961,7 @@ system Segesta
 		period 10
 	object
 		sprite planet/venus-b
-		distance 333
+		distance 1128.81
 		period 117.777
 		object
 			sprite planet/dust5
@@ -21969,7 +21969,7 @@ system Segesta
 			period 27.0988
 	object
 		sprite planet/forest2
-		distance 918.01
+		distance 3472.33
 		period 539.097
 		object
 			sprite planet/rock0-b
@@ -21977,7 +21977,7 @@ system Segesta
 			period 21.3838
 	object
 		sprite planet/browndwarf-t
-		distance 1408.25
+		distance 5586.38
 		period 1024.27
 		object
 			sprite planet/tethys-b
@@ -21985,11 +21985,11 @@ system Segesta
 			period 27
 	object "Ember Wormhole"
 		sprite planet/wormhole-red
-		distance 2749.5
+		distance 11768.16
 		period 2794.32
 	object
 		sprite planet/gas2-b
-		distance 2749.5
+		distance 11768.16
 		period 2794.32
 		offset 180
 
@@ -21998,8 +21998,8 @@ system Seginus
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 135
-	belt 1906
+	habitable 416.76
+	belt 7823.54
 	link Alnasl
 	link Wei
 	link Alphecca
@@ -22029,23 +22029,23 @@ system Seginus
 		period 10
 	object Clark
 		sprite planet/forest6-b
-		distance 140.09
+		distance 434.1
 		period 57.0826
 	object
 		sprite planet/cloud0
-		distance 460.34
+		distance 1615.23
 		period 340.025
 	object
 		sprite planet/rock9-b
-		distance 1164.98
+		distance 4524.41
 		period 1368.9
 	object
 		sprite planet/ice0
-		distance 1643.42
+		distance 6633.54
 		period 2293.59
 	object
 		sprite planet/neptune
-		distance 4413.46
+		distance 19955.07
 		period 10094
 		object
 			sprite planet/europa-b
@@ -22065,8 +22065,8 @@ system Seketra
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 425.92
-	belt 1465
+	habitable 1482.07
+	belt 5837.33
 	link Skeruto
 	link Chikatip
 	asteroids "large metal" 1 1.7556
@@ -22086,19 +22086,19 @@ system Seketra
 		period 10
 	object
 		sprite planet/rock8
-		distance 235.01
+		distance 768.04
 		period 69.8273
 	object "Seleptra Nak"
 		sprite planet/rock1
-		distance 433.85
+		distance 1512.65
 		period 175.148
 	object
 		sprite planet/ice2-b
-		distance 1126.26
+		distance 4357.61
 		period 732.578
 	object
 		sprite planet/gas3
-		distance 2033.62
+		distance 8409.06
 		period 1777.46
 		object
 			sprite planet/dust7
@@ -22118,8 +22118,8 @@ system Sepetrosk
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1286
+	habitable 1717.88
+	belt 5049.8
 	link Chimitarp
 	link Feroteri
 	link Similisti
@@ -22148,19 +22148,19 @@ system Sepetrosk
 		period 10
 	object
 		sprite planet/rock10
-		distance 267.04
+		distance 884.43
 		period 79.123
 	object "Fek Rembatu"
 		sprite planet/desert6
-		distance 550.45
+		distance 1968.94
 		period 234.161
 	object
 		sprite planet/dust2
-		distance 738.14
+		distance 2725.88
 		period 363.619
 	object
 		sprite planet/gas15-b
-		distance 1532.58
+		distance 6137.65
 		period 1087.86
 		object "Esek Stovar"
 			sprite planet/station2k
@@ -22168,7 +22168,7 @@ system Sepetrosk
 			period 21.742
 	object
 		sprite planet/uranus-b
-		distance 2511.66
+		distance 10639.12
 		period 2282.33
 		object
 			sprite planet/lava0-b
@@ -22180,8 +22180,8 @@ system Sepriaptu
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 2035
-	belt 1120
+	habitable 8415.42
+	belt 4330.71
 	link Kaliptari
 	link Sabriset
 	asteroids "small rock" 127 4.34
@@ -22205,19 +22205,19 @@ system Sepriaptu
 	fleet "Large Quarg" 4000
 	object
 		sprite star/f5
-		distance 16.1966
+		distance 40.79
 		period 9.26902
 	object
 		sprite star/m0
-		distance 86.8034
+		distance 256.36
 		period 9.26902
 	object
 		sprite planet/desert7-b
-		distance 362.451
+		distance 1239.73
 		period 61.1859
 	object
 		sprite planet/rock4-b
-		distance 1644.91
+		distance 6640.23
 		period 591.547
 		object
 			sprite planet/station3kd
@@ -22225,7 +22225,7 @@ system Sepriaptu
 			period 41.1893
 	object
 		sprite planet/rock17-b
-		distance 2309.96
+		distance 9691.47
 		period 984.431
 
 system Sevrelect
@@ -22233,8 +22233,8 @@ system Sevrelect
 	government "Kor Efret"
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1763
+	habitable 1080.19
+	belt 7172.91
 	haze _menu/haze-67
 	link Sumprast
 	link Kashikt
@@ -22257,23 +22257,23 @@ system Sevrelect
 		period 10
 	object
 		sprite planet/dust2-b
-		distance 168.61
+		distance 532.45
 		period 48.9565
 	object "Setar Fort"
 		sprite planet/forest4-b
-		distance 364.42
+		distance 1247.18
 		period 155.557
 	object
 		sprite planet/rock2
-		distance 1157.59
+		distance 4492.53
 		period 880.683
 	object
 		sprite planet/ice7-b
-		distance 1568.89
+		distance 6299.65
 		period 1389.55
 	object
 		sprite planet/gas12
-		distance 2345.33
+		distance 9856.97
 		period 2539.75
 		object
 			sprite planet/station3kd
@@ -22285,8 +22285,8 @@ system Shaula
 	government Pirate
 	attributes "south"
 	arrival 1500
-	habitable 625
-	belt 1814
+	habitable 2266.58
+	belt 7404.27
 	link Lesath
 	asteroids "small rock" 1 3.2016
 	asteroids "medium rock" 2 3.5496
@@ -22318,19 +22318,19 @@ system Shaula
 		period 10
 	object
 		sprite planet/desert3
-		distance 230.61
+		distance 752.18
 		period 56.0321
 	object Greenrock
 		sprite planet/cloud1
-		distance 502.57
+		distance 1780.11
 		period 180.266
 	object
 		sprite planet/ocean8-b
-		distance 861.82
+		distance 3237.18
 		period 404.804
 	object
 		sprite planet/rock1-b
-		distance 1374.03
+		distance 5435.62
 		period 814.919
 		object
 			sprite planet/dust0-b
@@ -22338,7 +22338,7 @@ system Shaula
 			period 16.3428
 	object
 		sprite planet/gas7
-		distance 2840.12
+		distance 12201.44
 		period 2421.73
 		object
 			sprite planet/miranda
@@ -22354,8 +22354,8 @@ system Sheratan
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 2035
-	belt 1183
+	habitable 8415.42
+	belt 4602.26
 	haze _menu/haze-133
 	link Ruchbah
 	link Zaurak
@@ -22378,20 +22378,20 @@ system Sheratan
 	fleet "Korath Raid" 30000
 	object
 		sprite star/f5
-		distance 21.0713
+		distance 54.36
 		period 13.7542
 		offset 180
 	object
 		sprite star/k5
-		distance 112.929
+		distance 342.4
 		period 13.7542
 	object
 		sprite planet/fog0-b
-		distance 372.929
+		distance 1279.43
 		period 63.8582
 	object
 		sprite planet/gas5
-		distance 845.179
+		distance 3167.87
 		period 217.872
 		object
 			sprite planet/rock7-b
@@ -22399,23 +22399,23 @@ system Sheratan
 			period 11.6399
 	object Sundive
 		sprite planet/ocean1
-		distance 1329.34
+		distance 5239.38
 		period 429.765
 	object
 		sprite planet/rhea-b
-		distance 1632.5
+		distance 6584.51
 		period 584.867
 	object
 		sprite planet/dust3-b
-		distance 4399.99
+		distance 19887.07
 		period 2587.95
 
 system Si'yak'ku
 	pos -329.235 -760.435
 	government Wanderer
 	arrival 1500
-	habitable 1313.28
-	belt 1985
+	habitable 5169.05
+	belt 8185.47
 	haze _menu/haze-none
 	link Ek'kek'ru
 	link Pik'ro'iyak
@@ -22443,16 +22443,16 @@ system Si'yak'ku
 	fleet "Wanderer Defense" 9000
 	object
 		sprite star/g0
-		distance 19.5395
+		distance 50.06
 		period 12.7342
 	object
 		sprite star/m4
-		distance 90.4605
+		distance 268.26
 		period 12.7342
 		offset 180
 	object
 		sprite planet/cloud7
-		distance 309.501
+		distance 1041.08
 		period 60.0999
 		object
 			sprite planet/oberon-b
@@ -22460,7 +22460,7 @@ system Si'yak'ku
 			period 19.018
 	object
 		sprite planet/gas13
-		distance 1215.75
+		distance 4744.09
 		period 467.895
 		object "Var' Roi"
 			sprite planet/ice8
@@ -22480,7 +22480,7 @@ system Si'yak'ku
 			period 46.0285
 	object
 		sprite planet/gas9-b
-		distance 2341.11
+		distance 9837.21
 		period 1250.3
 		object
 			sprite planet/lava0-b
@@ -22495,8 +22495,8 @@ system Sich'ka'ara
 	pos -97.1237 -831.921
 	government Wanderer
 	arrival 1500
-	habitable 1715
-	belt 1744
+	habitable 6955.87
+	belt 7086.92
 	haze _menu/haze-none
 	link Prakacha'a
 	link Ap'arak
@@ -22520,7 +22520,7 @@ system Sich'ka'ara
 		period 10
 	object
 		sprite planet/gas10
-		distance 368
+		distance 1260.74
 		period 68.1867
 		object
 			sprite planet/dust1
@@ -22528,7 +22528,7 @@ system Sich'ka'ara
 			period 17.7652
 	object
 		sprite planet/mars-b
-		distance 926
+		distance 3505.9
 		period 272.173
 		object
 			sprite planet/rock17-b
@@ -22536,11 +22536,11 @@ system Sich'ka'ara
 			period 20.2683
 	object
 		sprite planet/tethys
-		distance 1182.49
+		distance 4600.06
 		period 392.757
 	object "Vara Ke'sok"
 		sprite planet/ocean6
-		distance 2370.98
+		distance 9977.17
 		period 1115.12
 		offset 337.352
 
@@ -22549,8 +22549,8 @@ system Silikatakfar
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 425.92
-	belt 1641
+	habitable 1482.07
+	belt 6622.67
 	link Mesuket
 	link Eneremprukt
 	link Asikafarnut
@@ -22577,11 +22577,11 @@ system Silikatakfar
 		period 10
 	object
 		sprite planet/miranda
-		distance 155.41
+		distance 486.69
 		period 37.5504
 	object "Sasirka Gatru"
 		sprite planet/rock6
-		distance 445.293
+		distance 1556.88
 		period 182.123
 		offset 99.2705
 		object
@@ -22590,7 +22590,7 @@ system Silikatakfar
 			period 20.8235
 	object
 		sprite planet/gas2
-		distance 1189.91
+		distance 4632.15
 		period 795.554
 		offset 328.062
 		object "Sebra Skira"
@@ -22604,8 +22604,8 @@ system "Silver Bell"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1080
-	belt 1406
+	habitable 4159.2
+	belt 5576.45
 	link "Bright Void"
 	link "Silver String"
 	link "Broken Bowl"
@@ -22641,23 +22641,23 @@ system "Silver Bell"
 		period 10
 	object
 		sprite planet/gas4-hot
-		distance 265.49
+		distance 878.77
 		period 25.9123
 	object
 		sprite planet/gas4-b
-		distance 615.1
+		distance 2226.81
 		period 185.681
 	object
 		sprite planet/tethys
-		distance 1195.71
+		distance 4657.25
 		period 503.254
 	object "Chosen Nexus"
 		sprite planet/cloud3
-		distance 1355.87
+		distance 5355.78
 		period 607.68
 	object
 		sprite planet/gas3-b
-		distance 2442.31
+		distance 10312.24
 		period 1469.09
 		object
 			sprite planet/rock17
@@ -22673,8 +22673,8 @@ system "Silver String"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1080
-	belt 1986
+	habitable 4159.2
+	belt 8190.06
 	link "Silver Bell"
 	asteroids "small rock" 4 1.209
 	asteroids "medium rock" 44 1.131
@@ -22707,11 +22707,11 @@ system "Silver String"
 		period 10
 	object
 		sprite planet/lava4-b
-		distance 157.61
+		distance 494.29
 		period 24.0837
 	object
 		sprite planet/gas12
-		distance 678.17
+		distance 2481.35
 		period 214.959
 		object
 			sprite planet/dust1
@@ -22719,11 +22719,11 @@ system "Silver String"
 			period 14.4054
 	object "Deep Treasure"
 		sprite planet/ocean2
-		distance 1197.42
+		distance 4664.66
 		period 504.334
 	object
 		sprite planet/gas11-b
-		distance 2649.46
+		distance 11291.79
 		period 1659.91
 		object
 			sprite planet/dust0
@@ -22739,8 +22739,8 @@ system Similisti
 	government "Kor Mereti"
 	attributes "korath"
 	arrival 1500
-	habitable 1080
-	belt 1349
+	habitable 4159.2
+	belt 5325.62
 	haze _menu/haze-133
 	link Chimitarp
 	link Mekislepti
@@ -22776,23 +22776,23 @@ system Similisti
 		period 10
 	object
 		sprite planet/cloud6-b
-		distance 175
+		distance 554.75
 		period 28.1777
 	object
 		sprite planet/rock15-b
-		distance 541.24
+		distance 1932.47
 		period 153.261
 	object
 		sprite planet/cloud5-b
-		distance 813.65
+		distance 3036.98
 		period 282.491
 	object "Sapira Mereti"
 		sprite planet/rock13
-		distance 1088.29
+		distance 4194.68
 		period 436.984
 	object
 		sprite planet/gas15
-		distance 1960.01
+		distance 8070.8
 		period 1056.18
 		object
 			sprite planet/europa
@@ -22808,8 +22808,8 @@ system Sirius
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 1800
-	belt 1407
+	habitable 7340.68
+	belt 5580.86
 	link Sol
 	link Procyon
 	link Eteron
@@ -22840,32 +22840,32 @@ system Sirius
 	fleet "Republic Logistics" 2500
 	object
 		sprite star/f5
-		distance 3.94301
+		distance 8.79
 		period 8.13257
 		offset 180
 	object
 		sprite star/m8
-		distance 86.557
+		distance 255.56
 		period 8.13257
 	object
 		sprite planet/lava4
-		distance 338.347
+		distance 1148.87
 		period 58.7893
 	object
 		sprite planet/rock6-b
-		distance 640.587
+		distance 2329.33
 		period 153.152
 	object
 		sprite planet/dust3
-		distance 1158.2
+		distance 4495.16
 		period 372.33
 	object Relic
 		sprite planet/dust4
-		distance 1807.21
+		distance 7373.42
 		period 725.716
 	object
 		sprite planet/tethys
-		distance 2162.3
+		distance 9003.83
 		period 949.79
 
 system Skeruto
@@ -22873,8 +22873,8 @@ system Skeruto
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1198
+	habitable 1080.19
+	belt 4667.17
 	link Furmeliki
 	link Meftarkata
 	link Fornarep
@@ -22897,15 +22897,15 @@ system Skeruto
 		period 10
 	object
 		sprite planet/lava0
-		distance 188.56
+		distance 602.34
 		period 57.8974
 	object "Sabira Eseskrai"
 		sprite planet/desert8
-		distance 395.37
+		distance 1364.88
 		period 175.789
 	object
 		sprite planet/desert10
-		distance 913.509
+		distance 3453.43
 		period 617.383
 		object
 			sprite planet/station1kd
@@ -22913,7 +22913,7 @@ system Skeruto
 			period 28.4644
 	object
 		sprite planet/gas11
-		distance 1806.49
+		distance 7370.15
 		period 1716.87
 		object
 			sprite planet/ice8-b
@@ -22924,8 +22924,8 @@ system Sko'karak
 	pos -304.43 -930.688
 	government Wanderer
 	arrival 1500
-	habitable 320
-	belt 1805
+	habitable 1080.19
+	belt 7363.39
 	haze _menu/haze-none
 	link Ka'ch'chrai
 	asteroids "medium rock" 8 2.4495
@@ -22950,19 +22950,19 @@ system Sko'karak
 		period 10
 	object
 		sprite planet/rock8
-		distance 154.36
+		distance 483.07
 		period 42.8832
 	object
 		sprite planet/rock18
-		distance 384.05
+		distance 1321.71
 		period 168.293
 	object
 		sprite planet/desert1
-		distance 617.3
+		distance 2235.64
 		period 342.949
 	object
 		sprite planet/gas4
-		distance 1227.46
+		distance 4794.91
 		period 961.603
 		object
 			sprite planet/callisto-b
@@ -22978,8 +22978,8 @@ system Sobarati
 	government "Kor Sestor"
 	attributes "korath"
 	arrival 1500
-	habitable 3780
-	belt 1314
+	habitable 16785.16
+	belt 5172.2
 	link Asikafarnut
 	asteroids "large metal" 1 3.705
 	trade Clothing 408
@@ -22996,20 +22996,20 @@ system Sobarati
 	fleet "Large Kor Sestor" 4000
 	object
 		sprite star/a5
-		distance 4.57143
+		distance 10.31
 		period 9.4217
 		offset 180
 	object
 		sprite star/m8
-		distance 123.429
+		distance 377.6
 		period 9.4217
 	object
 		sprite planet/rock7-b
-		distance 247.469
+		distance 813.12
 		period 25.3276
 	object
 		sprite planet/gas14
-		distance 1008.08
+		distance 3852.67
 		period 208.236
 		object
 			sprite planet/io-b
@@ -23029,7 +23029,7 @@ system Sobarati
 			period 56.2979
 	object
 		sprite planet/gas0
-		distance 2435.19
+		distance 10278.74
 		period 781.833
 		object "Devru Kaska"
 			sprite planet/station1k
@@ -23041,8 +23041,8 @@ system Sol
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 1080
-	belt 1529
+	habitable 4159.2
+	belt 6121.71
 	haze _menu/haze-67
 	link Vega
 	link "Alpha Centauri"
@@ -23078,15 +23078,15 @@ system Sol
 		period 25.38
 	object
 		sprite planet/mercury
-		distance 289.647
+		distance 967.52
 		period 60
 	object
 		sprite planet/venus
-		distance 533.534
+		distance 1902.01
 		period 150
 	object Earth
 		sprite planet/earth
-		distance 965.669
+		distance 3673.07
 		period 365.25
 		object Luna
 			sprite planet/luna
@@ -23094,11 +23094,11 @@ system Sol
 			period 27.3
 	object Mars
 		sprite planet/mars
-		distance 1471.43
+		distance 5865.84
 		period 687
 	object
 		sprite planet/jupiter
-		distance 3000
+		distance 12969.87
 		period 2000
 		object
 			sprite planet/io
@@ -23122,8 +23122,8 @@ system "Sol Arach"
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 486.68
-	belt 1147
+	habitable 1717.88
+	belt 4446.88
 	haze _menu/haze-133
 	link Meblumem
 	link Gupta
@@ -23163,23 +23163,23 @@ system "Sol Arach"
 		period 10
 	object
 		sprite planet/desert1-b
-		distance 176.84
+		distance 561.18
 		period 42.6392
 	object Ahr
 		sprite planet/forest2-b
-		distance 465.3
+		distance 1634.51
 		period 181.986
 	object
 		sprite planet/rock11
-		distance 706.54
+		distance 2596.74
 		period 340.52
 	object
 		sprite planet/gas4-b
-		distance 1022.54
+		distance 3914.1
 		period 592.869
 	object
 		sprite planet/gas14-b
-		distance 3419.3
+		distance 15007.81
 		period 3625.3
 		object
 			sprite planet/miranda-b
@@ -23195,8 +23195,8 @@ system "Sol Kimek"
 	government Coalition
 	attributes "kimek"
 	arrival 1500
-	habitable 425.92
-	belt 1490
+	habitable 1482.07
+	belt 5948.25
 	link "3 Pole"
 	link "11 Autumn Above"
 	link "4 Winter Rising"
@@ -23233,11 +23233,11 @@ system "Sol Kimek"
 		period 10
 	object
 		sprite planet/rock8-b
-		distance 137.16
+		distance 424.11
 		period 31.1342
 	object "Ki Patek Ka"
 		sprite planet/ocean1
-		distance 679.68
+		distance 2487.48
 		period 343.442
 		offset 43.5788
 		object "Starting Rubin"
@@ -23247,7 +23247,7 @@ system "Sol Kimek"
 			offset 56.4009
 	object
 		sprite planet/gas12-b
-		distance 1153.05
+		distance 4472.95
 		period 758.871
 		object
 			sprite planet/europa
@@ -23263,7 +23263,7 @@ system "Sol Kimek"
 			period 31.325
 	object
 		sprite planet/dust1
-		distance 2429.06
+		distance 10249.91
 		period 2320.35
 
 system "Sol Saryd"
@@ -23271,8 +23271,8 @@ system "Sol Saryd"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1313.28
-	belt 1720
+	habitable 5169.05
+	belt 6978.45
 	link Belonging
 	link "Ancient Hope"
 	link Companion
@@ -23302,24 +23302,24 @@ system "Sol Saryd"
 	fleet Heliarch 900
 	object
 		sprite star/g0
-		distance 19.7171
+		distance 50.55
 		period 12.9082
 		offset 180
 	object
 		sprite star/m4
-		distance 91.2829
+		distance 270.94
 		period 12.9082
 	object
 		sprite planet/rock0
-		distance 199.893
+		distance 642.4
 		period 31.1945
 	object
 		sprite planet/desert5-b
-		distance 380.453
+		distance 1308.02
 		period 81.9092
 	object
 		sprite planet/rock10-b
-		distance 754.743
+		distance 2793.99
 		period 228.865
 		object
 			sprite planet/rock17-b
@@ -23327,7 +23327,7 @@ system "Sol Saryd"
 			period 14.5432
 	object Saros
 		sprite planet/forest2
-		distance 1376.69
+		distance 5447.32
 		period 563.817
 		object Revelation
 			sprite planet/dust0
@@ -23339,7 +23339,7 @@ system "Sol Saryd"
 			period 45.5271
 	object
 		sprite planet/ocean9
-		distance 2042.37
+		distance 8449.37
 		period 1018.79
 		object
 			sprite planet/ice8-b
@@ -23347,7 +23347,7 @@ system "Sol Saryd"
 			period 20.7199
 	object
 		sprite planet/gas11
-		distance 2533.21
+		distance 10740.92
 		period 1407.31
 
 system Solifar
@@ -23355,8 +23355,8 @@ system Solifar
 	government Uninhabited
 	attributes "korath"
 	arrival 1500
-	habitable 320
-	belt 1517
+	habitable 1080.19
+	belt 6068.28
 	haze _menu/haze-67
 	link Kaliptari
 	asteroids "small rock" 7 7.772
@@ -23384,11 +23384,11 @@ system Solifar
 		period 10
 	object "Desi Seledrak"
 		sprite planet/cloud5
-		distance 270.64
+		distance 897.62
 		period 99.5573
 	object
 		sprite planet/gas14
-		distance 974.08
+		distance 3708.62
 		period 679.793
 		object
 			sprite planet/luna-b
@@ -23404,7 +23404,7 @@ system Solifar
 			period 46.0792
 	object
 		sprite planet/gas7
-		distance 2068.97
+		distance 8572.02
 		period 2104.34
 
 system Sospi
@@ -23412,8 +23412,8 @@ system Sospi
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1715
-	belt 1715
+	habitable 6955.87
+	belt 6955.87
 	haze _menu/haze-133
 	link Volax
 	link Nihal
@@ -23447,19 +23447,19 @@ system Sospi
 		period 100
 	object
 		sprite planet/lava2-b
-		distance 152.96
+		distance 478.25
 		period 18.2724
 	object
 		sprite planet/lava7
-		distance 362.32
+		distance 1239.23
 		period 66.6141
 	object
 		sprite planet/lava4
-		distance 656.93
+		distance 2395.32
 		period 162.632
 	object
 		sprite planet/gas16-b
-		distance 2355.57
+		distance 9904.93
 		period 1104.26
 		object
 			sprite planet/dust3
@@ -23479,8 +23479,8 @@ system Speloog
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 625
-	belt 1159
+	habitable 2266.58
+	belt 4498.61
 	link Belug
 	link Ekuarik
 	link Torbab
@@ -23511,11 +23511,11 @@ system Speloog
 		period 10
 	object
 		sprite planet/rock10
-		distance 243.56
+		distance 798.95
 		period 60.8176
 	object "Dwelling of Speloog"
 		sprite planet/forest4-b
-		distance 627.77
+		distance 2277.72
 		period 251.664
 		object
 			sprite planet/callisto-b
@@ -23523,15 +23523,15 @@ system Speloog
 			period 16.7891
 	object
 		sprite planet/europa
-		distance 1013.86
+		distance 3877.21
 		period 516.52
 	object
 		sprite planet/rock17
-		distance 1912.47
+		distance 7853.12
 		period 1338.17
 	object
 		sprite planet/uranus-b
-		distance 3373.43
+		distance 14783.35
 		period 3134.93
 		object
 			sprite planet/io
@@ -23547,8 +23547,8 @@ system Spica
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 625
-	belt 1940
+	habitable 2266.58
+	belt 7979.1
 	haze _menu/haze-33
 	link Minkar
 	link "Gamma Corvi"
@@ -23581,19 +23581,19 @@ system Spica
 		period 10
 	object
 		sprite planet/desert4-b
-		distance 112.25
+		distance 340.13
 		period 19.0283
 	object Oasis
 		sprite planet/forest0-b
-		distance 401.46
+		distance 1388.17
 		period 128.701
 	object
 		sprite planet/dust4-b
-		distance 1099.46
+		distance 4242.55
 		period 583.296
 	object
 		sprite planet/gas7-b
-		distance 2243.46
+		distance 9381.12
 		period 1700.19
 		object
 			sprite planet/ganymede
@@ -23609,7 +23609,7 @@ system Statina
 	government Uninhabited
 	attributes "ember waste" "wormhole" "inaccessible"
 	arrival 1500
-	habitable 135
+	habitable 416.76
 	haze _menu/haze-red
 	link Diespiter
 	link Egeria
@@ -23627,19 +23627,19 @@ system Statina
 		period 10
 	object
 		sprite planet/desert4
-		distance 111
+		distance 335.97
 		period 30
 	object
 		sprite planet/dust3
-		distance 308
+		distance 1035.5
 		period 142
 	object
 		sprite planet/gas8
-		distance 636
+		distance 2310.85
 		period 420
 	object
 		sprite planet/ice5
-		distance 1364
+		distance 5391.51
 		period 84
 		object
 			sprite planet/dust4
@@ -23647,7 +23647,7 @@ system Statina
 			period 17
 	object "Wormhole Link"
 		sprite planet/wormhole-red
-		distance 2754
+		distance 11789.63
 		period 389
 
 system "Steep Roof"
@@ -23655,8 +23655,8 @@ system "Steep Roof"
 	government Coalition
 	attributes "saryd"
 	arrival 1500
-	habitable 1080
-	belt 1100
+	habitable 4159.2
+	belt 4244.86
 	haze _menu/haze-67
 	link "Bright Void"
 	asteroids "small rock" 30 5.4918
@@ -23689,11 +23689,11 @@ system "Steep Roof"
 		period 10
 	object
 		sprite planet/lava3
-		distance 167.04
+		distance 526.99
 		period 26.2772
 	object "Ceaseless Toil"
 		sprite planet/cloud8
-		distance 494.8
+		distance 1749.66
 		period 133.965
 		object
 			sprite planet/lava0-b
@@ -23701,7 +23701,7 @@ system "Steep Roof"
 			period 24.2278
 	object "Warm Slope"
 		sprite planet/cloud6
-		distance 1010.56
+		distance 3863.2
 		period 391.013
 		object
 			sprite planet/luna-b
@@ -23709,7 +23709,7 @@ system "Steep Roof"
 			period 21.8962
 	object
 		sprite planet/gas17-b
-		distance 2828.56
+		distance 12146.08
 		period 1831.03
 		object
 			sprite planet/callisto
@@ -23729,8 +23729,8 @@ system Stercutus
 	government Uninhabited
 	attributes "ember waste" "wormhole"
 	arrival 1500
-	habitable 945
-	belt 1492
+	habitable 3585.87
+	belt 5957.13
 	haze _menu/haze-red
 	link Caeculus
 	link Peragenor
@@ -23754,24 +23754,24 @@ system Stercutus
 	hazard "Ember Waste Base Storm" 9000
 	object
 		sprite star/g5-old
-		distance 31.1534
+		distance 83.34
 		period 11.4822
 	object
 		sprite star/m0
-		distance 60.8466
+		distance 173.53
 		period 11.4822
 		offset 180
 	object
 		sprite planet/cloud6-b
-		distance 244.937
+		distance 803.94
 		period 49.8798
 	object
 		sprite planet/titan
-		distance 466.297
+		distance 1638.39
 		period 131.02
 	object
 		sprite planet/gas11-b
-		distance 1449.31
+		distance 5767.84
 		period 717.934
 		object
 			sprite planet/rock7-b
@@ -23787,7 +23787,7 @@ system Stercutus
 			period 30.2335
 	object
 		sprite planet/gas14
-		distance 2557.67
+		distance 10856.58
 		period 1683.1
 
 system Suhail
@@ -23795,8 +23795,8 @@ system Suhail
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 1715
-	belt 1715
+	habitable 6955.87
+	belt 6955.87
 	haze _menu/haze-33
 	link Regor
 	asteroids "small rock" 2 2.8224
@@ -23829,15 +23829,15 @@ system Suhail
 		period 10
 	object
 		sprite planet/water1
-		distance 193.41
+		distance 619.45
 		period 25.9804
 	object
 		sprite planet/io-b
-		distance 461.7
+		distance 1620.51
 		period 95.8226
 	object
 		sprite planet/gas14-b
-		distance 1034.31
+		distance 3964.18
 		period 321.295
 		object "Leviathan Station"
 			sprite planet/station6
@@ -23845,7 +23845,7 @@ system Suhail
 			period 15.4109
 	object Helheim
 		sprite planet/ocean9
-		distance 1842.75
+		distance 7535.03
 		period 764.06
 		object
 			sprite planet/europa
@@ -23857,8 +23857,8 @@ system Sumar
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 2560
-	belt 1778
+	habitable 10867.61
+	belt 7240.88
 	link Cardax
 	link Hassaleh
 	link Danoa
@@ -23882,11 +23882,11 @@ system Sumar
 		period 10
 	object
 		sprite planet/lava6
-		distance 242.16
+		distance 793.88
 		period 29.7916
 	object
 		sprite planet/desert6-b
-		distance 619.12
+		distance 2242.95
 		period 121.787
 		object
 			sprite planet/miranda-b
@@ -23894,7 +23894,7 @@ system Sumar
 			period 14.6679
 	object
 		sprite planet/gas15
-		distance 1673.12
+		distance 6767.09
 		period 541.042
 		object
 			sprite planet/rock14-b
@@ -23918,8 +23918,8 @@ system Sumprast
 	government "Kor Efret"
 	attributes "korath"
 	arrival 1500
-	habitable 486.68
-	belt 1958
+	habitable 1717.88
+	belt 8061.58
 	haze _menu/haze-67
 	link Kashikt
 	link Sevrelect
@@ -23949,11 +23949,11 @@ system Sumprast
 		period 10
 	object
 		sprite planet/desert7
-		distance 158.16
+		distance 496.19
 		period 36.0648
 	object "Karek Fornati"
 		sprite planet/desert0
-		distance 478.16
+		distance 1684.61
 		period 189.582
 		object
 			sprite planet/dust5
@@ -23961,11 +23961,11 @@ system Sumprast
 			period 25.2033
 	object
 		sprite planet/callisto-b
-		distance 1256.4
+		distance 4920.75
 		period 807.477
 	object
 		sprite planet/gas0-b
-		distance 2549.84
+		distance 10819.54
 		period 2334.57
 		object
 			sprite planet/dust1-b
@@ -23985,8 +23985,8 @@ system Tais
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 3645
-	belt 1379
+	habitable 16117.46
+	belt 5457.49
 	haze _menu/haze-133
 	link "Delta Sagittarii"
 	link "Kaus Australis"
@@ -24020,23 +24020,23 @@ system Tais
 		period 10
 	object
 		sprite planet/venus-b
-		distance 259.21
+		distance 855.83
 		period 27.6496
 	object
 		sprite planet/water0
-		distance 525.45
+		distance 1870.11
 		period 79.801
 	object
 		sprite planet/rock16-b
-		distance 814.7
+		distance 3041.33
 		period 154.066
 	object
 		sprite planet/rock3-b
-		distance 1915.66
+		distance 7867.7
 		period 555.506
 	object
 		sprite planet/dust7
-		distance 2265.3
+		distance 9482.93
 		period 714.332
 
 system Talita
@@ -24044,8 +24044,8 @@ system Talita
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1705
-	belt 1403
+	habitable 6910.75
+	belt 5563.22
 	link Miaplacidus
 	link Alphard
 	link Castor
@@ -24078,32 +24078,32 @@ system Talita
 	fleet "Human Miners" 3000
 	object
 		sprite star/g0
-		distance 42.8886
+		distance 118.26
 		period 12.2596
 		offset 180
 	object
 		sprite star/g5
-		distance 74.1114
+		distance 215.48
 		period 12.2596
 	object
 		sprite planet/lava2
-		distance 314.951
+		distance 1061.36
 		period 54.1456
 	object
 		sprite planet/rock14-b
-		distance 529.761
+		distance 1887.11
 		period 118.119
 	object
 		sprite planet/lava1-b
-		distance 760.451
+		distance 2817.44
 		period 203.144
 	object Hestia
 		sprite planet/forest4
-		distance 1550.01
+		distance 6215.36
 		period 591.153
 	object
 		sprite planet/gas16
-		distance 2193.3
+		distance 9147.75
 		period 995.051
 
 system "Tania Australis"
@@ -24111,8 +24111,8 @@ system "Tania Australis"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1738
+	habitable 4159.2
+	belt 7059.78
 	link Phecda
 	link Algieba
 	link Fala
@@ -24145,15 +24145,15 @@ system "Tania Australis"
 		period 10
 	object
 		sprite planet/desert5
-		distance 251.49
+		distance 827.72
 		period 48.5433
 	object
 		sprite planet/cloud8-b
-		distance 637.9
+		distance 2318.5
 		period 196.1
 	object
 		sprite planet/gas4-b
-		distance 1122.15
+		distance 4339.95
 		period 457.535
 		object Ingot
 			sprite planet/callisto
@@ -24161,7 +24161,7 @@ system "Tania Australis"
 			period 12.2578
 	object
 		sprite planet/gas15-b
-		distance 3139.51
+		distance 13644.39
 		period 2141.12
 		object
 			sprite planet/lava2-b
@@ -24185,8 +24185,8 @@ system Tarazed
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 1215
-	belt 1169
+	habitable 4740.84
+	belt 4541.77
 	link Enif
 	link Albireo
 	link Dabih
@@ -24212,24 +24212,24 @@ system Tarazed
 	fleet "Large Southern Pirates" 8000
 	object
 		sprite star/g0
-		distance 11
+		distance 26.76
 		period 11.3038
 	object
 		sprite star/m4
-		distance 88
+		distance 260.25
 		period 11.3038
 		offset 180
 	object
 		sprite planet/desert5
-		distance 321.64
+		distance 1086.31
 		period 66.1953
 	object
 		sprite planet/cloud7-b
-		distance 557.45
+		distance 1996.7
 		period 151.036
 	object Wayfarer
 		sprite planet/cloud2
-		distance 1221.26
+		distance 4768.0
 		period 489.761
 		object Echo
 			sprite planet/dust3
@@ -24237,7 +24237,7 @@ system Tarazed
 			period 18.9407
 	object
 		sprite planet/gas15-b
-		distance 1880.55
+		distance 7707.32
 		period 935.835
 		object "Arachne Station"
 			sprite planet/station11
@@ -24249,8 +24249,8 @@ system Tebuteb
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 553.28
-	belt 1855
+	habitable 1980.16
+	belt 7590.82
 	link Miblulub
 	link Glubatub
 	asteroids "small rock" 7 2.0468
@@ -24279,16 +24279,16 @@ system Tebuteb
 	fleet Heliarch 250
 	object
 		sprite star/m0
-		distance 40.0549
+		distance 109.73
 		period 15.7461
 		offset 180
 	object
 		sprite star/m4
-		distance 54.9451
+		distance 155.16
 		period 15.7461
 	object "Tebuteb's Table"
 		sprite planet/cloud3
-		distance 454.983
+		distance 1594.43
 		period 165.037
 		object
 			sprite planet/dust5
@@ -24296,15 +24296,15 @@ system Tebuteb
 			period 20.6063
 	object
 		sprite planet/rock19-b
-		distance 816.943
+		distance 3050.62
 		period 397.078
 	object
 		sprite planet/gas13
-		distance 1300.7
+		distance 5114.02
 		period 797.728
 	object
 		sprite planet/gas12
-		distance 2511.99
+		distance 10640.68
 		period 2140.99
 
 system Tejat
@@ -24312,8 +24312,8 @@ system Tejat
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 1158.12
-	belt 1447
+	habitable 4494.82
+	belt 5757.61
 	link Phurad
 	link Miaplacidus
 	asteroids "small rock" 5 4.5675
@@ -24342,16 +24342,16 @@ system Tejat
 	fleet "Large Republic" 2000
 	object
 		sprite star/g0
-		distance 7.1843
+		distance 16.84
 		period 12.9183
 	object
 		sprite star/m8
-		distance 99.3157
+		distance 297.27
 		period 12.9183
 		offset 180
 	object
 		sprite planet/lava4-b
-		distance 444.026
+		distance 1551.97
 		period 109.975
 		object
 			sprite planet/lava2
@@ -24359,7 +24359,7 @@ system Tejat
 			period 18.9022
 	object Calda
 		sprite planet/cloud6
-		distance 976.466
+		distance 3718.71
 		period 358.647
 		object
 			sprite planet/dust0
@@ -24367,7 +24367,7 @@ system Tejat
 			period 18.4539
 	object Vail
 		sprite planet/ice2
-		distance 1542.03
+		distance 6179.77
 		period 711.737
 		object
 			sprite planet/dust4-b
@@ -24375,7 +24375,7 @@ system Tejat
 			period 21.5952
 	object
 		sprite planet/gas12
-		distance 2957.47
+		distance 12764.97
 		period 1890.44
 		object
 			sprite planet/dust2-b
@@ -24391,8 +24391,8 @@ system Terminus
 	government Republic
 	attributes "wormhole" "dirt belt"
 	arrival 1500
-	habitable 425.92
-	belt 1221
+	habitable 1482.07
+	belt 4766.87
 	haze _menu/haze-67
 	link Limen
 	asteroids "small rock" 29 4.046
@@ -24421,15 +24421,15 @@ system Terminus
 		period 10
 	object
 		sprite planet/gas11
-		distance 284.16
+		distance 947.29
 		period 92.8411
 	object
 		sprite planet/desert4-b
-		distance 666.8
+		distance 2435.26
 		period 333.725
 	object
 		sprite planet/jupiter
-		distance 1040.64
+		distance 3991.14
 		period 650.649
 		object
 			sprite planet/rhea
@@ -24437,7 +24437,7 @@ system Terminus
 			period 11.9034
 	object "Ember Threshold"
 		sprite planet/wormhole-red
-		distance 2077.64
+		distance 8612.04
 		period 1835.49
 
 system "Terra Incognita"
@@ -24446,7 +24446,7 @@ system "Terra Incognita"
 	attributes "pleiades"
 	link "Over the Rainbow"
 	arrival 1500
-	habitable 455.625
+	habitable 1596.92
 	haze _menu/haze-blackbody
 	asteroids "small rock" 8 1.8432
 	asteroids "medium rock" 1 1.8144
@@ -24459,19 +24459,19 @@ system "Terra Incognita"
 		period 10
 	object
 		sprite planet/lava4
-		distance 174.59
+		distance 553.31
 		period 43.230003
 	object Ruin
 		sprite planet/ocean9
-		distance 461.84
+		distance 1621.06
 		period 185.99169
 	object
 		sprite planet/cloud8
-		distance 862.65
+		distance 3240.64
 		period 474.79721
 	object
 		sprite planet/gas2
-		distance 2203.49
+		distance 9195.11
 		period 1938.3083
 		object
 			sprite planet/ganymede
@@ -24491,8 +24491,8 @@ system Torbab
 	government Coalition
 	attributes "arachi"
 	arrival 1500
-	habitable 1505.92
-	belt 1702
+	habitable 6018.99
+	belt 6897.21
 	link Speloog
 	link Debrugt
 	link Flugbu
@@ -24524,28 +24524,28 @@ system Torbab
 	fleet Heliarch 250
 	object
 		sprite star/g0
-		distance 26.8689
+		distance 70.89
 		period 9.54431
 	object
 		sprite star/k5-old
-		distance 68.1311
+		distance 196.47
 		period 9.54431
 		offset 180
 	object
 		sprite planet/luna-b
-		distance 240.541
+		distance 788.02
 		period 38.4541
 	object
 		sprite planet/rock15
-		distance 385.181
+		distance 1326.02
 		period 77.9213
 	object
 		sprite planet/mars-b
-		distance 659.221
+		distance 2404.58
 		period 174.464
 	object
 		sprite planet/gas8-b
-		distance 1535.78
+		distance 6151.91
 		period 620.373
 		object
 			sprite planet/rock0-b
@@ -24557,7 +24557,7 @@ system Torbab
 			period 22.3171
 	object
 		sprite planet/neptune-b
-		distance 2533.14
+		distance 10740.59
 		period 1314.16
 		object
 			sprite planet/rock14-b
@@ -24569,8 +24569,8 @@ system Tortor
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 455.625
-	belt 1243
+	habitable 1596.92
+	belt 4862.44
 	haze _menu/haze-67
 	link Gorvi
 	link Mintaka
@@ -24601,23 +24601,23 @@ system Tortor
 		period 10
 	object
 		sprite planet/rock17-b
-		distance 188.99
+		distance 603.85
 		period 48.6872
 	object
 		sprite planet/titan
-		distance 431.43
+		distance 1503.31
 		period 167.927
 	object
 		sprite planet/cloud3
-		distance 767.64
+		distance 2847.01
 		period 398.559
 	object
 		sprite planet/rock18-b
-		distance 1259.4
+		distance 4933.82
 		period 837.533
 	object
 		sprite planet/gas13
-		distance 2240.61
+		distance 9367.85
 		period 1987.49
 		object
 			sprite planet/rock0-b
@@ -24637,8 +24637,8 @@ system Turais
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 320
-	belt 1471
+	habitable 1080.19
+	belt 5863.93
 	link Gacrux
 	link "Delta Velorum"
 	link Algorel
@@ -24671,7 +24671,7 @@ system Turais
 		period 10
 	object Gemstone
 		sprite planet/cloud7
-		distance 271
+		distance 898.93
 		period 99.756
 		object
 			sprite planet/lava0-b
@@ -24679,23 +24679,23 @@ system Turais
 			period 23.094
 	object
 		sprite planet/rock18
-		distance 680.76
+		distance 2491.86
 		period 397.17
 	object
 		sprite planet/dust3
-		distance 993.76
+		distance 3791.93
 		period 700.499
 	object
 		sprite planet/gas10
-		distance 2424.17
+		distance 10226.92
 		period 2668.88
 
 system "Ula Mon"
 	pos -64.1218 -559.868
 	government Hai
 	arrival 1500
-	habitable 640
-	belt 1574
+	habitable 2326.97
+	belt 6322.49
 	link "Bote Asu"
 	link "Mei Yohn"
 	link "Io Lowe"
@@ -24725,39 +24725,39 @@ system "Ula Mon"
 	fleet "Hai Surveillance" 3000
 	object
 		sprite star/m0
-		distance 56.5
+		distance 159.98
 		period 18.9927
 		offset 180
 	object
 		sprite star/m0
-		distance 56.5
+		distance 159.98
 		period 18.9927
 	object
 		sprite planet/rock5
-		distance 194.91
+		distance 624.75
 		period 43.025
 	object
 		sprite planet/ganymede
-		distance 365.32
+		distance 1250.59
 		period 110.403
 	object Makerplace
 		sprite planet/desert2
-		distance 597.32
+		distance 2155.57
 		period 230.824
 		offset 221.651
 	object
 		sprite planet/desert0-b
-		distance 1109.57
+		distance 4285.92
 		period 584.389
 		offset 301.398
 	object
 		sprite planet/rock6-b
-		distance 1370.41
+		distance 5419.69
 		period 802.132
 		offset 325.062
 	object
 		sprite planet/gas8-b
-		distance 7288.57
+		distance 34960.45
 		period 9838.6
 		offset 359.444
 		object
@@ -24770,8 +24770,8 @@ system "Ultima Thule"
 	government Republic
 	attributes "wormhole" "north"
 	arrival 1500
-	habitable 2560
-	belt 1635
+	habitable 10867.61
+	belt 6595.73
 	haze _menu/haze-67
 	link Rajak
 	asteroids "small rock" 2 2.4966
@@ -24797,19 +24797,19 @@ system "Ultima Thule"
 		period 10
 	object
 		sprite planet/desert5
-		distance 200
+		distance 642.78
 		period 22.3607
 	object
 		sprite planet/europa-b
-		distance 403.41
+		distance 1395.63
 		period 64.056
 	object
 		sprite planet/desert7-b
-		distance 824.9
+		distance 3083.62
 		period 187.302
 	object
 		sprite planet/gas1
-		distance 1706.99
+		distance 6919.72
 		period 557.553
 		object
 			sprite planet/ice8-b
@@ -24817,7 +24817,7 @@ system "Ultima Thule"
 			period 11.1964
 	object "Wormhole Alpha"
 		sprite planet/wormhole
-		distance 4208.63
+		distance 18923.68
 		period 2158.5
 
 system Umbral
@@ -24825,8 +24825,8 @@ system Umbral
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 670
-	belt 1345
+	habitable 2448.22
+	belt 5308.06
 	link Tarazed
 	asteroids "small rock" 4 7.1925
 	asteroids "medium rock" 21 4.2525
@@ -24851,24 +24851,24 @@ system Umbral
 	fleet "Large Southern Pirates" 6000
 	object
 		sprite star/k0-old
-		distance 31.3563
+		distance 83.93
 		period 14.9921
 	object
 		sprite star/m0
-		distance 66.6437
+		distance 191.76
 		period 14.9921
 		offset 180
 	object
 		sprite planet/desert9-b
-		distance 273.504
+		distance 908.12
 		period 69.8984
 	object
 		sprite planet/rock17
-		distance 524.194
+		distance 1865.15
 		period 185.464
 	object
 		sprite planet/gas2
-		distance 1241.83
+		distance 4857.36
 		period 676.266
 		object
 			sprite planet/europa
@@ -24880,7 +24880,7 @@ system Umbral
 			period 25.3223
 	object
 		sprite planet/uranus
-		distance 2517.84
+		distance 10668.3
 		period 1952.39
 		object
 			sprite planet/ice7-b
@@ -24904,8 +24904,8 @@ system Unagi
 	government Pirate
 	attributes "north"
 	arrival 1500
-	habitable 320
-	belt 1960
+	habitable 1080.19
+	belt 8070.75
 	haze _menu/haze-33
 	link Almaaz
 	asteroids "large rock" 1 3.102
@@ -24931,19 +24931,19 @@ system Unagi
 		period 10
 	object
 		sprite planet/lava3-b
-		distance 144.41
+		distance 448.87
 		period 38.8044
 	object
 		sprite planet/rock6
-		distance 430.25
+		distance 1498.76
 		period 199.557
 	object
 		sprite planet/mars-b
-		distance 772.94
+		distance 2868.83
 		period 480.511
 	object
 		sprite planet/gas13
-		distance 2336.98
+		distance 9817.87
 		period 2526.2
 		object
 			sprite planet/rock7-b
@@ -24959,8 +24959,8 @@ system Unukalhai
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 625
-	belt 1968
+	habitable 2266.58
+	belt 8107.44
 	haze _menu/haze-67
 	link Zubenelgenubi
 	link Sabik
@@ -24993,15 +24993,15 @@ system Unukalhai
 		period 10
 	object
 		sprite planet/water0-b
-		distance 197.41
+		distance 633.6
 		period 44.3786
 	object Flood
 		sprite planet/ice4
-		distance 591.97
+		distance 2134.18
 		period 230.446
 	object
 		sprite planet/ocean0
-		distance 1146.86
+		distance 4446.28
 		period 621.421
 		object
 			sprite planet/lava2
@@ -25009,19 +25009,19 @@ system Unukalhai
 			period 25.5161
 	object
 		sprite planet/ice0
-		distance 1949.5
+		distance 8022.62
 		period 1377.22
 	object
 		sprite planet/miranda-b
-		distance 3243.71
+		distance 14150.53
 		period 2955.85
 
 system "Uwa Fahn"
 	pos 35.1585 -491.67
 	government Hai
 	arrival 1500
-	habitable 320
-	belt 1913
+	habitable 1080.19
+	belt 7855.54
 	link "Ya Hai"
 	asteroids "small rock" 26 3.9349
 	asteroids "medium rock" 14 2.2743
@@ -25052,19 +25052,19 @@ system "Uwa Fahn"
 		period 10
 	object
 		sprite planet/desert8-b
-		distance 151.84
+		distance 474.39
 		period 41.8374
 	object Icelake
 		sprite planet/forest2
-		distance 393.93
+		distance 1359.38
 		period 174.829
 	object
 		sprite planet/ice6-b
-		distance 616.77
+		distance 2233.52
 		period 342.507
 	object
 		sprite planet/rock4
-		distance 1093.66
+		distance 4217.69
 		period 808.739
 		object
 			sprite planet/dust3
@@ -25072,7 +25072,7 @@ system "Uwa Fahn"
 			period 21.6202
 	object
 		sprite planet/gas7
-		distance 3713.55
+		distance 16456.14
 		period 5060.21
 
 system Vaticanus
@@ -25080,7 +25080,7 @@ system Vaticanus
 	government Uninhabited
 	attributes "ember waste" "inaccessible"
 	arrival 1500
-	habitable 320
+	habitable 1080.19
 	haze _menu/haze-red
 	link Egeria
 	link Prosa
@@ -25099,14 +25099,14 @@ system Vaticanus
 		period 19
 	object
 		sprite planet/ice6
-		distance 261
+		distance 862.36
 		period 73
 	object
 		sprite planet/tethys
-		distance 768
+		distance 2848.49
 		period 368
 	object
-		distance 1670
+		distance 6753.04
 		period 1181
 		sprite planet/gas16
 		object
@@ -25115,7 +25115,7 @@ system Vaticanus
 			period 14
 	object
 		sprite planet/uranus
-		distance 2105
+		distance 8738.46
 		period 3438
 		object
 			sprite planet/luna
@@ -25123,7 +25123,7 @@ system Vaticanus
 			period 14
 	object "Wormhole Link"
 		sprite planet/wormhole-red
-		distance 2754
+		distance 11789.63
 		period 389
 
 system Vega
@@ -25131,8 +25131,8 @@ system Vega
 	government Republic
 	attributes "near earth"
 	arrival 1500
-	habitable 1400
-	belt 1744
+	habitable 5549.99
+	belt 7086.92
 	link Altair
 	link Sol
 	link Menkent
@@ -25163,24 +25163,24 @@ system Vega
 	fleet "Human Miners" 5000
 	object
 		sprite star/g0
-		distance 23.3143
+		distance 60.71
 		period 11.0128
 		offset 180
 	object
 		sprite star/k5
-		distance 78.6857
+		distance 230.14
 		period 11.0128
 	object
 		sprite planet/rock12
-		distance 314.696
+		distance 1060.41
 		period 59.6805
 	object
 		sprite planet/gas12-b
-		distance 714.136
+		distance 2627.72
 		period 204.017
 	object Silver
 		sprite planet/cloud3
-		distance 1359.23
+		distance 5370.55
 		period 535.714
 		object
 			sprite planet/dust5-b
@@ -25188,7 +25188,7 @@ system Vega
 			period 22.8905
 	object
 		sprite planet/gas8
-		distance 2981.84
+		distance 12882.34
 		period 1740.69
 
 system Vindemiatrix
@@ -25196,8 +25196,8 @@ system Vindemiatrix
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1080
-	belt 1957
+	habitable 4159.2
+	belt 8056.99
 	link Alioth
 	link Muhlifain
 	link "Cor Caroli"
@@ -25230,19 +25230,19 @@ system Vindemiatrix
 		period 10
 	object
 		sprite planet/cloud0
-		distance 162.25
+		distance 510.36
 		period 25.155
 	object
 		sprite planet/rock4
-		distance 542.69
+		distance 1938.21
 		period 153.878
 	object "New Argentina"
 		sprite planet/forest0-b
-		distance 943.05
+		distance 3577.65
 		period 352.493
 	object
 		sprite planet/rhea
-		distance 2091.26
+		distance 8674.95
 		period 1164.02
 
 system Volax
@@ -25250,8 +25250,8 @@ system Volax
 	government Republic
 	attributes "north"
 	arrival 1500
-	habitable 1715
-	belt 1424
+	habitable 6955.87
+	belt 5655.91
 	haze _menu/haze-67
 	link Cardax
 	link Nihal
@@ -25278,19 +25278,19 @@ system Volax
 		period 10
 	object
 		sprite planet/desert1-b
-		distance 185.25
+		distance 590.69
 		period 24.3537
 	object
 		sprite planet/desert3-b
-		distance 582.5
+		distance 2096.38
 		period 135.791
 	object
 		sprite planet/callisto-b
-		distance 930.54
+		distance 3524.99
 		period 274.177
 	object
 		sprite planet/gas7-b
-		distance 1423.83
+		distance 5655.16
 		period 518.938
 		object
 			sprite planet/rock0
@@ -25298,15 +25298,15 @@ system Volax
 			period 11.3185
 	object
 		sprite planet/rock17-b
-		distance 4455.87
+		distance 20169.35
 		period 2872.94
 
 system "Wah Ki"
 	pos 14.9925 -612.792
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1585
+	habitable 1482.07
+	belt 6371.67
 	link "Zuba Zub"
 	link "Wah Yoot"
 	link "Bote Asu"
@@ -25339,11 +25339,11 @@ system "Wah Ki"
 		period 10
 	object
 		sprite planet/rock11
-		distance 131.84
+		distance 406.03
 		period 29.3404
 	object Cloudfire
 		sprite planet/cloud0
-		distance 492.05
+		distance 1738.89
 		period 211.548
 		object
 			sprite planet/luna-b
@@ -25351,19 +25351,19 @@ system "Wah Ki"
 			period 19.978
 	object
 		sprite planet/rock14-b
-		distance 764.14
+		distance 2832.61
 		period 409.407
 	object
 		sprite planet/mars
-		distance 1456.55
+		distance 5799.89
 		period 1077.42
 	object
 		sprite planet/rock7-b
-		distance 1787.44
+		distance 7283.69
 		period 1464.68
 	object
 		sprite planet/gas6-b
-		distance 2204.44
+		distance 9199.53
 		period 2006.06
 		object
 			sprite planet/dust0
@@ -25374,8 +25374,8 @@ system "Wah Oh"
 	pos -205.344 -381.381
 	government Hai
 	arrival 1500
-	habitable 5000
-	belt 1194
+	habitable 22939.71
+	belt 4649.85
 	haze _menu/haze-67
 	link "Io Mann"
 	link "Due Yoot"
@@ -25410,11 +25410,11 @@ system "Wah Oh"
 		period 10
 	object
 		sprite planet/gas8-hot
-		distance 341.76
+		distance 1161.69
 		period 17.1522
 	object
 		sprite planet/gas11
-		distance 897.53
+		distance 3386.42
 		period 152.107
 		object
 			sprite planet/rock14
@@ -25422,7 +25422,7 @@ system "Wah Oh"
 			period 15.6189
 	object
 		sprite planet/gas15
-		distance 1607.69
+		distance 6473.25
 		period 364.652
 		object
 			sprite planet/tethys
@@ -25430,7 +25430,7 @@ system "Wah Oh"
 			period 16.248
 	object
 		sprite planet/gas12
-		distance 2963.45
+		distance 12793.76
 		period 912.581
 		object
 			sprite planet/miranda-b
@@ -25446,15 +25446,15 @@ system "Wah Oh"
 			period 30.9656
 	object Farwater
 		sprite planet/water0
-		distance 4021.38
+		distance 17986.07
 		period 1442.57
 
 system "Wah Yoot"
 	pos 40.9382 -685.994
 	government "Hai (Unfettered)"
 	arrival 1500
-	habitable 1080
-	belt 1222
+	habitable 4159.2
+	belt 4771.21
 	link "Wah Ki"
 	link "Ehma Ti"
 	link "Hi Yahr"
@@ -25483,15 +25483,15 @@ system "Wah Yoot"
 		period 10
 	object
 		sprite planet/cloud3
-		distance 163.44
+		distance 514.48
 		period 25.4323
 	object
 		sprite planet/desert4
-		distance 474.85
+		distance 1671.7
 		period 125.946
 	object
 		sprite planet/desert2-b
-		distance 852.94
+		distance 3200.17
 		period 303.198
 		object
 			sprite planet/ice0
@@ -25499,11 +25499,11 @@ system "Wah Yoot"
 			period 20.989
 	object Darkcloak
 		sprite planet/cloud4
-		distance 1297.43
+		distance 5099.73
 		period 568.819
 	object
 		sprite planet/gas7
-		distance 2677.43
+		distance 11424.77
 		period 1686.26
 		object
 			sprite planet/rock0-b
@@ -25519,8 +25519,8 @@ system Waypoint
 	government Hai
 	attributes "wormhole"
 	arrival 1500
-	habitable 78.125
-	belt 1610
+	habitable 228.34
+	belt 6483.6
 	haze _menu/haze-67
 	link "Heia Due"
 	asteroids "small rock" 9 2.8028
@@ -25550,11 +25550,11 @@ system Waypoint
 		period 10
 	object
 		sprite planet/rock8
-		distance 187.26
+		distance 597.76
 		period 115.966
 	object
 		sprite planet/gas16
-		distance 866.67
+		distance 3257.41
 		period 1154.64
 		object
 			sprite planet/lava0
@@ -25566,11 +25566,11 @@ system Waypoint
 			period 29.9522
 	object
 		sprite planet/luna-b
-		distance 1499.03
+		distance 5988.36
 		period 2626.52
 	object "Wormhole Alpha"
 		sprite planet/wormhole
-		distance 2079.28
+		distance 8619.61
 		period 4290.76
 
 system Wazn
@@ -25578,8 +25578,8 @@ system Wazn
 	government Republic
 	attributes "paradise"
 	arrival 1500
-	habitable 534.375
-	belt 1414
+	habitable 1905.33
+	belt 5611.75
 	haze _menu/haze-67
 	link Alhena
 	link Kursa
@@ -25608,24 +25608,24 @@ system Wazn
 	fleet "Republic Logistics" 5000
 	object
 		sprite star/k5
-		distance 45.5327
+		distance 126.27
 		period 20.9233
 	object
 		sprite star/m0
-		distance 67.9673
+		distance 195.95
 		period 20.9233
 		offset 180
 	object
 		sprite planet/lava5
-		distance 263.027
+		distance 869.76
 		period 73.8139
 	object Glory
 		sprite planet/forest1-b
-		distance 542.917
+		distance 1939.1
 		period 218.896
 	object
 		sprite planet/jupiter-b
-		distance 1357.76
+		distance 5364.09
 		period 865.705
 		object
 			sprite planet/ice0
@@ -25637,7 +25637,7 @@ system Wazn
 			period 24.7588
 	object
 		sprite planet/gas0-b
-		distance 2875.76
+		distance 12372.3
 		period 2668.49
 
 system Wei
@@ -25645,8 +25645,8 @@ system Wei
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 455.625
-	belt 1927
+	habitable 1596.92
+	belt 7919.58
 	link Seginus
 	link Alnasl
 	link Kornephoros
@@ -25672,19 +25672,19 @@ system Wei
 		period 10
 	object
 		sprite planet/dust2-b
-		distance 145.14
+		distance 451.38
 		period 32.767
 	object
 		sprite planet/lava1-b
-		distance 334.14
+		distance 1133.09
 		period 114.459
 	object Hope
 		sprite planet/ice2
-		distance 605.15
+		distance 2186.92
 		period 278.966
 	object
 		sprite planet/gas3-b
-		distance 2438.44
+		distance 10294.03
 		period 2256.44
 		object
 			sprite planet/lava0
@@ -25704,8 +25704,8 @@ system Wezen
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 2880
-	belt 1913
+	habitable 12392.65
+	belt 7855.54
 	link Naos
 	asteroids "small rock" 6 2.6418
 	asteroids "medium rock" 68 2.2372
@@ -25734,20 +25734,20 @@ system Wezen
 	fleet "Small Northern Pirates" 8000
 	object
 		sprite star/f0
-		distance 11.8889
+		distance 29.12
 		period 8.24972
 	object
 		sprite star/k5
-		distance 95.1111
+		distance 283.46
 		period 8.24972
 		offset 180
 	object
 		sprite planet/miranda-b
-		distance 255.401
+		distance 841.95
 		period 30.4227
 	object
 		sprite planet/gas5-b
-		distance 664.041
+		distance 2424.09
 		period 127.543
 		object "Phoenix Station"
 			sprite planet/station1
@@ -25755,11 +25755,11 @@ system Wezen
 			period 12.3538
 	object
 		sprite planet/water0-b
-		distance 1273.29
+		distance 4994.35
 		period 338.653
 	object Alfheim
 		sprite planet/forest0
-		distance 1768.53
+		distance 7197.96
 		period 554.348
 		object
 			sprite planet/ice0-b
@@ -25767,7 +25767,7 @@ system Wezen
 			period 19.8826
 	object
 		sprite planet/gas9-b
-		distance 3579.78
+		distance 15795.94
 		period 1596.42
 		object
 			sprite planet/rock0
@@ -25787,59 +25787,59 @@ system "World's End"
 	government Uninhabited
 	attributes "pleiades"
 	arrival 1500
-	habitable 700
+	habitable 2570.09
 	haze _menu/haze-blackbody
 	object
 		sprite star/g5
 		period 10
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 0
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 20
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 50
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 70
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 140
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 160
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 180
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 200
 	object
 		sprite "planet/ringworld right"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 270
 	object
 		sprite "planet/ringworld left"
-		distance 812
+		distance 3030.14
 		period 360
 		offset 290
 
@@ -25847,8 +25847,8 @@ system "Ya Hai"
 	pos -24.9453 -505.571
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1120
+	habitable 1482.07
+	belt 4330.71
 	link "Ula Mon"
 	link "Bote Asu"
 	link "Uwa Fahn"
@@ -25883,12 +25883,12 @@ system "Ya Hai"
 		period 10
 	object
 		sprite planet/ice6
-		distance 147.36
+		distance 458.99
 		period 34.6709
 		offset 249.973
 	object Hai-home
 		sprite planet/forest2-b
-		distance 512.61
+		distance 1819.55
 		period 224.945
 		offset 94.4538
 		object Mirrorlake
@@ -25897,7 +25897,7 @@ system "Ya Hai"
 			period 25.243
 	object
 		sprite planet/gas15-b
-		distance 1231.97
+		distance 4814.5
 		period 838.101
 		offset 287.069
 		object
@@ -25910,7 +25910,7 @@ system "Ya Hai"
 			period 26.1298
 	object
 		sprite planet/gas16-b
-		distance 2811.53
+		distance 12064.56
 		period 2889.42
 		offset 338.654
 		object
@@ -25923,8 +25923,8 @@ system "Yed Prior"
 	government Republic
 	attributes "south"
 	arrival 1500
-	habitable 455.625
-	belt 1837
+	habitable 1596.92
+	belt 7508.86
 	link Pherkad
 	asteroids "small rock" 12 5.0784
 	asteroids "medium rock" 1 2.9072
@@ -25957,19 +25957,19 @@ system "Yed Prior"
 		period 10
 	object
 		sprite planet/desert7
-		distance 158.5
+		distance 497.37
 		period 37.3938
 	object Winter
 		sprite planet/ocean0
-		distance 534.79
+		distance 1906.97
 		period 231.756
 	object
 		sprite planet/dust1-b
-		distance 776.2
+		distance 2882.25
 		period 405.244
 	object
 		sprite planet/gas7-b
-		distance 1903.69
+		distance 7812.98
 		period 1556.51
 		object
 			sprite planet/dust0
@@ -25981,8 +25981,8 @@ system Zaurak
 	government Syndicate
 	attributes "core"
 	arrival 1500
-	habitable 625
-	belt 1130
+	habitable 2266.58
+	belt 4373.7
 	haze _menu/haze-133
 	link Sheratan
 	link Alcyone
@@ -26016,23 +26016,23 @@ system Zaurak
 		period 10
 	object
 		sprite planet/rock14
-		distance 143.49
+		distance 445.73
 		period 27.5013
 	object Canyon
 		sprite planet/forest0-b
-		distance 453.13
+		distance 1587.24
 		period 154.331
 	object
 		sprite planet/dust4-b
-		distance 716.38
+		distance 2636.88
 		period 306.786
 	object
 		sprite planet/oberon
-		distance 959.42
+		distance 3646.68
 		period 475.481
 	object
 		sprite planet/dust0-b
-		distance 2871.42
+		distance 12351.48
 		period 2461.87
 
 system "Zeta Aquilae"
@@ -26040,8 +26040,8 @@ system "Zeta Aquilae"
 	government Republic
 	attributes "dirt belt"
 	arrival 1500
-	habitable 1400
-	belt 1829
+	habitable 5549.99
+	belt 7472.46
 	haze _menu/haze-133
 	link Ascella
 	link Rasalhague
@@ -26067,16 +26067,16 @@ system "Zeta Aquilae"
 	fleet "Large Southern Pirates" 5000
 	object
 		sprite star/g0
-		distance 22.6286
+		distance 58.76
 		period 10.5305
 	object
 		sprite star/k5
-		distance 76.3714
+		distance 222.71
 		period 10.5305
 		offset 180
 	object
 		sprite planet/gas1-b
-		distance 560.211
+		distance 2007.66
 		period 141.75
 		object
 			sprite planet/europa
@@ -26088,15 +26088,15 @@ system "Zeta Aquilae"
 			period 20.0948
 	object Rand
 		sprite planet/cloud7
-		distance 1233.05
+		distance 4819.19
 		period 462.879
 	object
 		sprite planet/rock17
-		distance 1657.41
+		distance 6696.41
 		period 721.342
 	object
 		sprite planet/gas0-b
-		distance 2460.57
+		distance 10398.2
 		period 1304.82
 		object
 			sprite planet/dust0-b
@@ -26116,8 +26116,8 @@ system "Zeta Centauri"
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 455.625
-	belt 1488
+	habitable 1596.92
+	belt 5939.37
 	haze _menu/haze-67
 	link Acrux
 	link Hadar
@@ -26145,27 +26145,27 @@ system "Zeta Centauri"
 		period 10
 	object
 		sprite planet/cloud4-b
-		distance 212.39
+		distance 686.85
 		period 58.0039
 	object Dune
 		sprite planet/cloud8
-		distance 474.64
+		distance 1670.88
 		period 193.777
 	object
 		sprite planet/lava3
-		distance 750.33
+		distance 2775.87
 		period 385.154
 	object
 		sprite planet/gas10
-		distance 1374.82
+		distance 5439.09
 		period 955.267
 	object
 		sprite planet/desert4
-		distance 1828.86
+		distance 7471.83
 		period 1465.64
 	object
 		sprite planet/gas4
-		distance 7491.3
+		distance 36050.15
 		period 12150.4
 
 system Zosma
@@ -26173,8 +26173,8 @@ system Zosma
 	government Republic
 	attributes "deep"
 	arrival 1500
-	habitable 455.625
-	belt 1436
+	habitable 1596.92
+	belt 5708.95
 	link Algieba
 	link Dubhe
 	link Alphard
@@ -26212,15 +26212,15 @@ system Zosma
 		period 10
 	object
 		sprite planet/gas11
-		distance 272.11
+		distance 903.0
 		period 84.1149
 	object Memory
 		sprite planet/cloud6
-		distance 644.75
+		distance 2346.13
 		period 306.791
 	object
 		sprite planet/gas0
-		distance 1637.56
+		distance 6607.22
 		period 1241.8
 		object "Huginn Station"
 			sprite planet/station16
@@ -26228,7 +26228,7 @@ system Zosma
 			period 13.4547
 	object
 		sprite planet/jupiter-b
-		distance 3585.81
+		distance 15825.64
 		period 4023.81
 		object "Muninn Station"
 			sprite planet/station12
@@ -26239,8 +26239,8 @@ system "Zuba Zub"
 	pos -48.2661 -647.926
 	government Hai
 	arrival 1500
-	habitable 425.92
-	belt 1911
+	habitable 1482.07
+	belt 7846.4
 	haze _menu/haze-67
 	link "Mei Yohn"
 	link "Imo Dep"
@@ -26270,15 +26270,15 @@ system "Zuba Zub"
 		period 10
 	object
 		sprite planet/dust6-b
-		distance 221.16
+		distance 718.22
 		period 63.7464
 	object Giverstone
 		sprite planet/desert0
-		distance 403.97
+		distance 1397.78
 		period 157.369
 	object
 		sprite planet/gas15-b
-		distance 909.22
+		distance 3435.43
 		period 531.373
 		object
 			sprite planet/callisto
@@ -26290,11 +26290,11 @@ system "Zuba Zub"
 			period 29.1483
 	object
 		sprite planet/cloud5
-		distance 1458.86
+		distance 5810.13
 		period 1079.98
 	object
 		sprite planet/gas3-b
-		distance 3987.87
+		distance 17818.82
 		period 4880.98
 		object
 			sprite planet/europa-b
@@ -26306,8 +26306,8 @@ system Zubenelgenubi
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 945
-	belt 1475
+	habitable 3585.87
+	belt 5881.67
 	link Zubeneschamali
 	link Unukalhai
 	link Sabik
@@ -26336,16 +26336,16 @@ system Zubenelgenubi
 	fleet "Large Southern Pirates" 5000
 	object
 		sprite star/g5
-		distance 32.8466
+		distance 88.3
 		period 12.4309
 	object
 		sprite star/k5
-		distance 64.1534
+		distance 183.91
 		period 12.4309
 		offset 180
 	object
 		sprite planet/lava5
-		distance 377.443
+		distance 1296.58
 		period 95.4162
 		object
 			sprite planet/dust3
@@ -26353,11 +26353,11 @@ system Zubenelgenubi
 			period 22.6337
 	object
 		sprite planet/desert9
-		distance 730.693
+		distance 2695.39
 		period 257.008
 	object
 		sprite planet/cloud0
-		distance 1318.13
+		distance 5190.28
 		period 622.706
 		object
 			sprite planet/rock14
@@ -26365,7 +26365,7 @@ system Zubenelgenubi
 			period 24.185
 	object
 		sprite planet/gas3
-		distance 1993.37
+		distance 8223.92
 		period 1158.05
 
 system Zubenelhakrabi
@@ -26373,8 +26373,8 @@ system Zubenelhakrabi
 	pos -755 365
 	government Uninhabited
 	arrival 1500
-	habitable 486.68
-	belt 1669
+	habitable 1717.88
+	belt 6748.54
 	asteroids "medium rock" 7 1.5946
 	asteroids "large rock" 1 1.5946
 	asteroids "medium metal" 12 2.8798
@@ -26397,17 +26397,17 @@ system Zubenelhakrabi
 		period 10
 	object
 		sprite planet/lava4
-		distance 147
+		distance 457.75
 		period 32.3158
 		offset 98.3841
 	object "Valley of the Damned"
 		sprite planet/earth
-		distance 502.704
+		distance 1780.64
 		period 204.365
 		offset 314.841
 	object
 		sprite planet/gas8
-		distance 1345.85
+		distance 5311.79
 		period 895.229
 		offset 153.957
 		object
@@ -26422,7 +26422,7 @@ system Zubenelhakrabi
 			offset 185.14
 	object
 		sprite planet/rock17
-		distance 2322.59
+		distance 9750.53
 		period 2029.54
 		offset 267.221
 		object
@@ -26432,7 +26432,7 @@ system Zubenelhakrabi
 			offset 44.2239
 	object
 		sprite planet/gas6
-		distance 3672.78
+		distance 16254.62
 		period 4035.81
 		offset 46.4282
 		object
@@ -26461,8 +26461,8 @@ system Zubeneschamali
 	government Republic
 	attributes "rim"
 	arrival 1500
-	habitable 1250
-	belt 1543
+	habitable 4892.89
+	belt 6184.1
 	haze _menu/haze-67
 	link Hadar
 	link Zubenelgenubi
@@ -26496,16 +26496,16 @@ system Zubeneschamali
 	fleet "Human Miners" 2000
 	object
 		sprite star/g5
-		distance 62
+		distance 177.15
 		period 15.622
 		offset 180
 	object
 		sprite star/g5-old
-		distance 62
+		distance 177.15
 		period 15.622
 	object
 		sprite planet/cloud8
-		distance 420.44
+		distance 1460.98
 		period 97.5351
 		object
 			sprite planet/desert4-b
@@ -26513,19 +26513,19 @@ system Zubeneschamali
 			period 23.094
 	object
 		sprite planet/ganymede-b
-		distance 880
+		distance 3313.07
 		period 295.345
 	object Zug
 		sprite planet/forest2-b
-		distance 1146.84
+		distance 4446.19
 		period 439.399
 	object
 		sprite planet/rock6-b
-		distance 1525.84
+		distance 6107.63
 		period 674.324
 	object
 		sprite planet/dust3
-		distance 2218.25
+		distance 9263.75
 		period 1182.01
 
 planet "Ablub's Invention"


### PR DESCRIPTION
**Feature:** X += X^1.15

## Feature Details
I have expanded distances within planets and stars within systems! Finally, it takes more than two seconds to jet across the system from one gas giant to another! This will make progress towards spreading in-system conflicts out, so battles are much less likely to occur on top of each other!

## UI Screenshots
~~Aww man you should see it, things aren't cramped any more!~~

## Usage Examples
N/A simply changed values from small numbers to larger numbers

## Testing Done
Flew around a bit, stuff looks cool! In busier systems with distant planets, fleets will jump in, and then coast to their destinations, forming little ant lines of activity!

## Performance Impact
N/A
