### PR TITLE
Slightly reduced the size of Remnant Generators.

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -331,7 +331,7 @@ outfit "Millennium Cell"
 		Remnant
 	cost 553000
 	thumbnail "outfit/millennium cell"
-	"mass" 29
+	"mass" 25
 	"outfit space" -29
 	"energy generation" 3.6
 	"heat generation" 6.0
@@ -345,7 +345,7 @@ outfit "Epoch Cell"
 		Remnant
 	cost 2123000
 	thumbnail "outfit/epoch cell"
-	"mass" 98
+	"mass" 85
 	"outfit space" -98
 	"energy generation" 12.7
 	"heat generation" 19.8
@@ -359,7 +359,7 @@ outfit "Aeon Cell"
 		Remnant
 	cost 4384000
 	thumbnail "outfit/aeon cell"
-	"mass" 160
+	"mass" 140
 	"outfit space" -160
 	"energy generation" 21.9
 	"heat generation" 31.5

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -332,7 +332,7 @@ outfit "Millennium Cell"
 	cost 553000
 	thumbnail "outfit/millennium cell"
 	"mass" 25
-	"outfit space" -25
+	"outfit space" -26
 	"energy generation" 3.6
 	"heat generation" 6.0
 	"ion resistance" 0.025
@@ -345,8 +345,8 @@ outfit "Epoch Cell"
 		Remnant
 	cost 2123000
 	thumbnail "outfit/epoch cell"
-	"mass" 85
-	"outfit space" -85
+	"mass" 83
+	"outfit space" -86
 	"energy generation" 12.7
 	"heat generation" 19.8
 	"ion resistance" 0.085
@@ -359,8 +359,8 @@ outfit "Aeon Cell"
 		Remnant
 	cost 4384000
 	thumbnail "outfit/aeon cell"
-	"mass" 140
-	"outfit space" -140
+	"mass" 136
+	"outfit space" -141
 	"energy generation" 21.9
 	"heat generation" 31.5
 	"ion resistance" 0.14

--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -332,7 +332,7 @@ outfit "Millennium Cell"
 	cost 553000
 	thumbnail "outfit/millennium cell"
 	"mass" 25
-	"outfit space" -29
+	"outfit space" -25
 	"energy generation" 3.6
 	"heat generation" 6.0
 	"ion resistance" 0.025
@@ -346,7 +346,7 @@ outfit "Epoch Cell"
 	cost 2123000
 	thumbnail "outfit/epoch cell"
 	"mass" 85
-	"outfit space" -98
+	"outfit space" -85
 	"energy generation" 12.7
 	"heat generation" 19.8
 	"ion resistance" 0.085
@@ -360,7 +360,7 @@ outfit "Aeon Cell"
 	cost 4384000
 	thumbnail "outfit/aeon cell"
 	"mass" 140
-	"outfit space" -160
+	"outfit space" -140
 	"energy generation" 21.9
 	"heat generation" 31.5
 	"ion resistance" 0.14


### PR DESCRIPTION
Small changes:

Millenium: 29 -> 25
Epoch: 98 -> 85
Aeon: 160 -> 140

This will naturally result in more space in Remnant ships, which could be taken up with more generation or heat dissipation (or security stations, if they had them), which would all match their longevity or survival ethos.