### PR TITLE
Increased Arach Spindle Mass.

### DIFF
--- a/data/coalition/coalition ships.txt
+++ b/data/coalition/coalition ships.txt
@@ -169,7 +169,7 @@ ship "Arach Spindle"
 		"hull" 9700
 		"required crew" 4
 		"bunks" 14
-		"mass" 500
+		"mass" 750
 		"drag" 10.8
 		"heat dissipation" .55
 		"fuel capacity" 500


### PR DESCRIPTION
I increased the Mass of the Spindle as much as I am comfortable without making the Hulk heavier that makes sense (to me). (500 Hull Mass > 750 Hull Mass)

This makes the Spindle noticably slower in all ways when equipped with the same engines. When utilizing the 1 extra Engine Capacity than the Pelican can manage, it results in noticably less turn, slightly higher accel, but much less top speed. If you were to bump the Pelican's Engine Capacity by 1, the Pelican becomes significantly faster in every way after this change (+300 max speed, +30 Accel, +15 Turn).

As noted on the Discord, I do feel that the Spindle competing with the Pelican is acceptable, but I do agree that it shouldn't be faster, which is why I have made this change. I am glad that we caught this one, and I will be happy to update any other ships you (or others) find. This is one of the reasons why I wanted to get these mass numbers out there, so that they can be improved.