### PR TITLE
Add new formation files to CodeBlocks build

### DIFF
--- a/EndlessSkyLib.cbp
+++ b/EndlessSkyLib.cbp
@@ -136,6 +136,10 @@
 		<Unit filename="source/Flotsam.h" />
 		<Unit filename="source/FogShader.cpp" />
 		<Unit filename="source/FogShader.h" />
+		<Unit filename="source/FormationPattern.cpp" />
+		<Unit filename="source/FormationPattern.h" />
+		<Unit filename="source/FormationPositioner.cpp" />
+		<Unit filename="source/FormationPositioner.h" />
 		<Unit filename="source/FrameTimer.cpp" />
 		<Unit filename="source/FrameTimer.h" />
 		<Unit filename="source/Galaxy.cpp" />


### PR DESCRIPTION
Prevents a link error in CodeBlocks caused by new source files not actually being built.