### PR TITLE
Digger Nerfs, New Damage Types

### DIFF
--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -884,7 +884,7 @@ outfit "Korath Digger Turret"
 	"mass" 19
 	"outfit space" -19
 	"weapon capacity" -19
-	miner 1
+	# miner 1
 	"asteroid scan power" 15
 	"turret mounts" -1
 	"required crew" 1
@@ -913,7 +913,7 @@ outfit "Korath Digger"
 	"mass" 17
 	"outfit space" -17
 	"weapon capacity" -17
-	miner 1
+	# miner 1
 	"asteroid scan power" 10
 	"gun ports" -1
 	weapon

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -878,6 +878,8 @@ outfit "Korath Digger Turret"
 	"mass" 19
 	"outfit space" -19
 	"weapon capacity" -19
+	miner 1
+	"asteroid scan power" 15
 	"turret mounts" -1
 	"required crew" 1
 	weapon
@@ -886,15 +888,15 @@ outfit "Korath Digger Turret"
 		"hardpoint sprite" "hardpoint/digger turret"
 		sound "korath digger"
 		"hit effect" "korath digger hit"
-		"inaccuracy" 1
-		"turret turn" 4.2
+		"inaccuracy" 1.5
+		"turret turn" 4.6
 		"velocity" 480
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2.4
+		"firing energy" 3.1
 		"firing heat" 5.2
-		"shield damage" 2.1
-		"hull damage" 4.2
+		"shield damage" 1.1
+		"hull damage" 3.2
 		"disruption damage" .04
 	description `When the Korath Exiles needed a cheap mining laser for their large vessels, they turned to an ancient but robust design. Updated with modern engineering, the mild shield disruption lets it damage ships as well, when multiple Diggers are used at once.`
 
@@ -905,20 +907,22 @@ outfit "Korath Digger"
 	"mass" 17
 	"outfit space" -17
 	"weapon capacity" -17
+	miner 1
+	"asteroid scan power" 10
 	"gun ports" -1
 	weapon
 		sprite "projectile/korath digger short"
 			"frame rate" 20
 		sound "korath digger"
 		"hit effect" "korath digger hit"
-		"inaccuracy" 0.4
-		"velocity" 400
+		"inaccuracy" 0.1
+		"velocity" 390
 		"lifetime" 1
 		"reload" 1
-		"firing energy" 2.4
-		"firing heat" 5.2
-		"shield damage" 2.1
-		"hull damage" 4.2
+		"firing energy"  2.9
+		"firing heat" 4.8
+		"shield damage" 1.1
+		"hull damage" 3.1
 		"disruption damage" .04
 	description `The basis for the design of a Korath Digger was an old turret. This modified version has no turret mount and is more accurate at the cost of a shorter range.`
 

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -251,8 +251,8 @@ outfit "Korath Fire-Lance"
 		"firing heat" 1.7
 		"shield damage" 3.5
 		"hull damage" 1.5
-		"heat damage" 6
-		"burning damage" 2
+		"heat damage" 8
+		"burn damage" .5
 		
 	description "The Korath Fire-Lance is a medium-range beam weapon designed to be used by their fighters."
 
@@ -751,7 +751,7 @@ outfit "Firestorm Turret"
 		"shield damage" 1900
 		"hull damage" 1900
 		"heat damage" 3600
-		"burning damage" 60
+		"burn damage" 25
 		"corrosion damage" 4
 		"hit force" 4000
 		"missile strength" 105
@@ -846,7 +846,7 @@ outfit "Korath Inferno"
 	"weapon capacity" -71
 	"turret mounts" -1
 	"required crew" 1
-	# Stats are the same as 3 Fire-Lances except 50% more heat damage, 100% more burning damage, double range, 5 more space, 10% more power, and 400% more heat generation. This takes about 120-130 space to support.
+	# Stats are the same as 3 Fire-Lances except 50% more heat damage, 50% more burn damage, double range, 5 more space, 10% more power, and 400% more heat generation. This takes about 120-130 space to support.
 	weapon
 		sprite "projectile/korath inferno"
 			"frame rate" 20
@@ -862,8 +862,8 @@ outfit "Korath Inferno"
 		"firing heat" 8.5
 		"shield damage" 10.5
 		"hull damage" 4.5
-		"heat damage" 27
-		"burning damage" 12
+		"heat damage" 36
+		"burn damage" 2.25
 	description "The Korath Inferno was the crowning achievement of Kor Sestor weapon design before they were driven out of their territory. The more efficient short-range Fire-Lance is based on this technology."
 
 effect "korath inferno hit"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -90,7 +90,8 @@ outfit "Korath Shunt-Strike"
 		"homing" 4
 		"tracking" .9
 		"shield damage" 48
-		"hull damage" 162
+		"hull damage" 122
+		"corrosion damage" 60
 		"piercing" 0.1
 		"slowing damage" 2.5
 	description "This dismantled Systems Core is attached to the firing mechanism of a Grab-Strike. It fires homing balls of repair microbots that eat through a target's shields and attempt to rebuild its hull and systems as Small Heat Shunts. They inevitably fail, but not before wreaking havoc on the ship."
@@ -251,6 +252,8 @@ outfit "Korath Fire-Lance"
 		"shield damage" 3.5
 		"hull damage" 1.5
 		"heat damage" 12
+		"burning damage" 2
+		
 	description "The Korath Fire-Lance is a medium-range beam weapon designed to be used by their fighters."
 
 effect "fire-lance impact"
@@ -748,9 +751,11 @@ outfit "Firestorm Turret"
 		"shield damage" 1900
 		"hull damage" 1900
 		"heat damage" 4200
+		"burning damage" 600
+		"corrosion damage" 40
 		"hit force" 4000
 		"missile strength" 105
-	description "This torpedo contains an augmented Korath Plasma Core reactor element, with no protective casing. When it activates, there is a tremendous explosion that heats up all ships in the vicinity and imparts a large hit force."
+	description "This torpedo contains an augmented Korath Plasma Core reactor element, with no protective casing. When it activates, there is a tremendous explosion of heat and force, pushing ships away and even melting hulls."
 	description `	Though the warhead is a simple Korath design, the torpedo casing and launcher are distinctly not Korath in style. This may be a device they discovered and learned to reproduce.`
 
 effect "firestorm ring"
@@ -841,7 +846,7 @@ outfit "Korath Inferno"
 	"weapon capacity" -71
 	"turret mounts" -1
 	"required crew" 1
-	# Stats are the same as 3 Fire-Lances except 50% more heat damage, double range, 5 more space, 10% more power, and 400% more heat generation. This takes about 120-130 space to support.
+	# Stats are the same as 3 Fire-Lances except 50% more heat damage, 100% more burning damage, double range, 5 more space, 10% more power, and 400% more heat generation. This takes about 120-130 space to support.
 	weapon
 		sprite "projectile/korath inferno"
 			"frame rate" 20
@@ -858,6 +863,7 @@ outfit "Korath Inferno"
 		"shield damage" 10.5
 		"hull damage" 4.5
 		"heat damage" 48
+		"burning damage" 12
 	description "The Korath Inferno was the crowning achievement of Kor Sestor weapon design before they were driven out of their territory. The more efficient short-range Fire-Lance is based on this technology."
 
 effect "korath inferno hit"

--- a/data/korath/korath weapons.txt
+++ b/data/korath/korath weapons.txt
@@ -90,8 +90,8 @@ outfit "Korath Shunt-Strike"
 		"homing" 4
 		"tracking" .9
 		"shield damage" 48
-		"hull damage" 122
-		"corrosion damage" 60
+		"hull damage" 102
+		"corrosion damage" 8
 		"piercing" 0.1
 		"slowing damage" 2.5
 	description "This dismantled Systems Core is attached to the firing mechanism of a Grab-Strike. It fires homing balls of repair microbots that eat through a target's shields and attempt to rebuild its hull and systems as Small Heat Shunts. They inevitably fail, but not before wreaking havoc on the ship."
@@ -251,7 +251,7 @@ outfit "Korath Fire-Lance"
 		"firing heat" 1.7
 		"shield damage" 3.5
 		"hull damage" 1.5
-		"heat damage" 12
+		"heat damage" 6
 		"burning damage" 2
 		
 	description "The Korath Fire-Lance is a medium-range beam weapon designed to be used by their fighters."
@@ -750,9 +750,9 @@ outfit "Firestorm Turret"
 		"blast radius" 90
 		"shield damage" 1900
 		"hull damage" 1900
-		"heat damage" 4200
-		"burning damage" 600
-		"corrosion damage" 40
+		"heat damage" 3600
+		"burning damage" 60
+		"corrosion damage" 4
 		"hit force" 4000
 		"missile strength" 105
 	description "This torpedo contains an augmented Korath Plasma Core reactor element, with no protective casing. When it activates, there is a tremendous explosion of heat and force, pushing ships away and even melting hulls."
@@ -862,7 +862,7 @@ outfit "Korath Inferno"
 		"firing heat" 8.5
 		"shield damage" 10.5
 		"hull damage" 4.5
-		"heat damage" 48
+		"heat damage" 27
 		"burning damage" 12
 	description "The Korath Inferno was the crowning achievement of Kor Sestor weapon design before they were driven out of their territory. The more efficient short-range Fire-Lance is based on this technology."
 


### PR DESCRIPTION
**Weapons**

Digger Nerfs - current is outright better than Ravagers, despite being a tier lower. Also some more changes to differentiate the Turret from the Gun versions, since the weight is so similar.

Both require more energy, and do less damage, but keep the small disruption. Turret turns a bit slower, and has even higher inaccuracy. Gun is even shorter range, but virtually no inaccuracy now, and slightly less energy and heat usage, all of which should help solidify it as solely a fighter and miner weapon.

Added mining laser changes from Revamp as well.

I know mining lasers as is in Revamp aren't likely to make it into vanilla, but they -might- be for the Korath versions. And I figured that having it included here would make an easier transition for these into revamp even if not.

Added corrosion damage to shunt strike in exchange for some hull damage and firestorm as an outright buff.
Added burning damage to firelance, firestorm, and inferno, in exchange for some heat damage.

All of these should be a bit stronger over time, but less powerful on immediate impact.