### PR TITLE
Fix Cost

### DIFF
--- a/data/remnant/remnant outfits.txt
+++ b/data/remnant/remnant outfits.txt
@@ -312,7 +312,7 @@ outfit "Ember Tear"
 	category "Secondary Weapons"
 	licenses
 		"Remnant Capital"
-	cost 50000000
+	cost 270000000
 	thumbnail "outfit/ember tear"
 	"mass" 250
 	"outfit space" -190


### PR DESCRIPTION
The Dragonflame has a default cost of 150M, and since this is even more powerful than that, it should have a more appropriate cost.