### PR TITLE
allow for deactivation of provoked on scan

### DIFF
--- a/data/remnant/remnant events.txt
+++ b/data/remnant/remnant events.txt
@@ -93,7 +93,7 @@ event "remnant: scanning tolerance"
 	government "Remnant"
 		"penalty for"
 			scan 0
-		"provoked on scan" 0
+		remove "provoked on scan"
 		"friendly hail" "remnant trusting"
 	government "Remnant (Research)"
 		"friendly hail" "remnant trusting"

--- a/source/Government.cpp
+++ b/source/Government.cpp
@@ -139,6 +139,9 @@ void Government::Load(const DataNode &node)
 			raidFleet = GameData::Fleets().Get(child.Token(1));
 		else if(child.Token(0) == "provoked on scan")
 			provokedOnScan = true;
+		else if(child.Token(0) == "remove" && child.Size() >= 2
+				&& child.Token(1) == "provoked on scan")
+			provokedOnScan = false;
 		else
 			child.PrintTrace("Skipping unrecognized attribute:");
 	}


### PR DESCRIPTION
Very small change, but it does the trick

As you can see, it was only looking at `else if(child.Token(0) == "provoked on scan")`, that's why `"provoked on scan" 0` caused no warnings, in fact it was activating it again.

`remove "provoked on scan"` will in fact remove it