### PR TITLE
One more thing

### DIFF
--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -99,8 +99,20 @@ void Preferences::Load()
 			vsyncIndex = max<int>(0, min<int>(node.Value(1), VSYNC_SETTINGS.size() - 1));
 		else if(node.Token(0) == "fullscreen")
 			screenModeIndex = max<int>(0, min<int>(node.Value(1), SCREEN_MODE_SETTINGS.size() - 1));
+		else if(node.Token(0) == "alert indicator")
+			alertIndicatorIndex = max<int>(0, min<int>(node.Value(1), ALERT_INDICATOR_SETTING.size()));
 		else
 			settings[node.Token(0)] = (node.Size() == 1 || node.Value(1));
+	}
+
+	// For people updating from a version before the visual red alert indicator,
+	// if they have already disabled the warning siren, don't turn the audible alert back on.
+	auto it = settings.find("Warning siren");
+	if(it != settings.end())
+	{
+		if(it->second)
+			alertIndicatorIndex = 2;
+		settings.erase(it);
 	}
 }
 
@@ -117,6 +129,7 @@ void Preferences::Save()
 	out.Write("boarding target", boardingIndex);
 	out.Write("view zoom", zoomIndex);
 	out.Write("vsync", vsyncIndex);
+	out.Write("alert indicator", alertIndicatorIndex);
 
 	for(const auto &it : settings)
 		out.Write(it.first, it.second);

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -110,7 +110,7 @@ void Preferences::Load()
 	auto it = settings.find("Warning siren");
 	if(it != settings.end())
 	{
-		if(it->second)
+		if(!it->second)
 			alertIndicatorIndex = 2;
 		settings.erase(it);
 	}

--- a/source/Preferences.cpp
+++ b/source/Preferences.cpp
@@ -67,7 +67,6 @@ void Preferences::Load()
 	settings[FRUGAL_ESCORTS] = true;
 	settings[EXPEND_AMMO] = true;
 	settings["Damaged fighters retreat"] = true;
-	settings["Warning siren"] = true;
 	settings["Show escort systems on map"] = true;
 	settings["Show stored outfits on map"] = true;
 	settings["Show mini-map"] = true;


### PR DESCRIPTION
I forgot to update Preferences::Load() and Preferences::Save().

Also, if a person has previously disabled the audible siren, we should only be enabling the visual indicator, not both.