### PR TITLE
Re-doing the start of the radar color fresh

### DIFF
--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -105,7 +105,7 @@ color "radar special" 0.5 1. 0.5 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
-color "radar star" 0.7 1. 1.
+color "radar star" 0.7 1. 1. 0.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -101,10 +101,11 @@ color "radar friendly" .4 .6 1. 0.
 color "radar unfriendly" .8 .8 .4 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
-color "radar special" 1. 1. 1. 0.
+color "radar special" 0.5 1. 0.5 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
+color "radar star" 0.7 1. 1.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -98,7 +98,7 @@ color "missile dangerous" 1. .1 .1 1.
 # Colors used in the radar map while in-flight.
 color "radar player" .2 1. 0. 0.
 color "radar friendly" .4 .6 1. 0.
-color "radar unfriendly" .8 .8 .4 0.
+color "radar unfriendly" .8 .8 .3 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
 color "radar special" 1. 1. 1. 0.

--- a/data/interfaces.txt
+++ b/data/interfaces.txt
@@ -101,11 +101,11 @@ color "radar friendly" .4 .6 1. 0.
 color "radar unfriendly" .8 .8 .4 0.
 color "radar hostile" .85 .3 .2 0.
 color "radar inactive" .4 .4 .4 0.
-color "radar special" 0.5 1. 0.5 0.
+color "radar special" 1. 1. 1. 0.
 color "radar anomalous" .7 0. 1. 0.
 color "radar blink" 1. 1. 1. 0.
 color "radar viewport" 0. .3 0. 0.
-color "radar star" 0.7 1. 1. 0.
+color "radar star" .6 .6 .6 0.
 
 # Colors used for warnings and errors.
 color "error back" .25 .1 .1 1.

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -52,6 +52,7 @@ void Radar::SetCenter(const Point &center)
 }
 
 
+
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -52,9 +52,6 @@ void Radar::SetCenter(const Point &center)
 }
 
 
-// Planets and stars both are circles, so they have "inner" as 0, but I can't
-// tell where it sets that. This may be clue to find where the identity of an object
-// is identified as a star.
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)

--- a/source/Radar.cpp
+++ b/source/Radar.cpp
@@ -33,6 +33,7 @@ const int Radar::SPECIAL = 5;
 const int Radar::ANOMALOUS = 6;
 const int Radar::BLINK = 7;
 const int Radar::VIEWPORT = 8;
+const int Radar::STAR = 9;
 
 
 
@@ -51,7 +52,9 @@ void Radar::SetCenter(const Point &center)
 }
 
 
-
+// Planets and stars both are circles, so they have "inner" as 0, but I can't
+// tell where it sets that. This may be clue to find where the identity of an object
+// is identified as a star.
 // Add an object. If "inner" is 0 it is a dot; otherwise, it is a ring. The
 // given position should be in world units (not shrunk to radar units).
 void Radar::Add(int type, Point position, double outer, double inner)
@@ -144,7 +147,8 @@ const Color &Radar::GetColor(int type)
 		*GameData::Colors().Get("radar special"),
 		*GameData::Colors().Get("radar anomalous"),
 		*GameData::Colors().Get("radar blink"),
-		*GameData::Colors().Get("radar viewport")
+		*GameData::Colors().Get("radar viewport"),
+		*GameData::Colors().Get("radar star")
 	};
 
 	if(static_cast<size_t>(type) >= color.size())

--- a/source/Radar.h
+++ b/source/Radar.h
@@ -37,6 +37,7 @@ public:
 	static const int ANOMALOUS;
 	static const int BLINK;
 	static const int VIEWPORT;
+	static const int STAR;
 
 
 public:

--- a/source/StellarObject.cpp
+++ b/source/StellarObject.cpp
@@ -98,7 +98,7 @@ const string &StellarObject::LandingMessage() const
 int StellarObject::RadarType(const Ship *ship) const
 {
 	if(IsStar())
-		return Radar::SPECIAL;
+		return Radar::STAR;
 	else if(!planet || !planet->IsAccessible(ship))
 		return Radar::INACTIVE;
 	else if(planet->IsWormhole())

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,7 +915,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
-
+// This looks relevant to setting if an object is a star, but it has no explanation.
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,7 +915,6 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
-// This looks relevant to setting if an object is a star, but it has no explanation.
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);

--- a/source/System.cpp
+++ b/source/System.cpp
@@ -915,6 +915,7 @@ void System::LoadObject(const DataNode &node, Set<Planet> &planets, int parent)
 }
 
 
+
 void System::LoadObjectHelper(const DataNode &node, StellarObject &object, bool removing)
 {
 	const string &key = node.Token(0);


### PR DESCRIPTION
Re-PR'ing to get rid of some weird update commits that snuck into the branch before they were on master...



Feature: This PR implements the feature request detailed and discussed in issue #{{insert number}}

This PR is for testing and figuring out what I'm doing and asking for help.

Here's what I've got so far:

- interfaces.txt has a section that specifies colors. Currently, the "special" color is the one that dictates the star color. I've changed it here for identification purposes. I have added a "radar star" line with another color. (it isn't actually used)
- radar.cpp has a list of constants that appears to be assigning each type of radar object a number. Or perhaps objects already have a number and what they are is being identified. I have added Radar::STAR = 9 to the list.
- radar.cpp also has a const Color section that I think is pulling the colors from gamedata, which I think means the interfaces.txt file. I have added a line for "radar star" to the list.
- radar.cpp has a section for drawing the radar that mentions circles without an inner. This is how planets and stars are drawn, so this could be a clue as to where the object is identified. Made a comment to this effect to help find it.
- System.cpp has a section that looks like it is identifying what things are, and has a object.isStar = line, but I don't know what it does. I added a comment to it so that it would be easy to find. Another section talked about using "friend system" to identify stuff.

Thanks to RisingLeaf who had already made some suggestions and pointers on the former PR #129 , 