### PR TITLE
Testing Code from vitalchip discussion in 8042

### DIFF
--- a/source/Ship.cpp
+++ b/source/Ship.cpp
@@ -2063,7 +2063,10 @@ void Ship::Move(vector<Visual> &visuals, list<shared_ptr<Flotsam>> &flotsam)
 				if((aNormal > 0.) != (vNormal > 0.) && fabs(aNormal) > fabs(vNormal))
 					dragAcceleration = -vNormal * angle.Unit();
 			}
-			velocity += dragAcceleration;
+			if(velocity.Length() > MaxVelocity() || velocity.Length() < 0.1)
+				velocity += dragAcceleration;
+			else
+				velocity += acceleration;
 		}
 		acceleration = Point();
 	}


### PR DESCRIPTION
This PR is intended to test building the "safer" experience described by vitalchip.


From the discussion in [8042 on the main repository
](https://github.com/endless-sky/endless-sky/issues/8042#issuecomment-1371928449)

vitalchip's post:
> If you change this:
> 
> [endless-sky/source/Ship.cpp](https://github.com/endless-sky/endless-sky/blob/c17c7eccae744ebdb4e7546e3002dc5e7a0aee1d/source/Ship.cpp#L2066)
> 
> Line 2066 in [c17c7ec](https://github.com/endless-sky/endless-sky/commit/c17c7eccae744ebdb4e7546e3002dc5e7a0aee1d)
>  velocity += dragAcceleration; 
> 
> To: velocity += acceleration;
> 
> You can experience no drag but it will be 'unlimited'. Speeds will get excessive and it'll be hard to come to a complete stop.
> 
> For a 'safer' experience I change it to:
> 
> 		if(velocity.Length() > MaxVelocity() || velocity.Length() < 0.1)
>              velocity += dragAcceleration;
> 		 else
> 			 velocity += acceleration;
> 
> This will provide a drag free experience up to the ship's max speed (as it would have been under drag) and also allow the ship to stop completely with greater ease.
> 
> You can do velocity.Length() > MaxVelocity() * 2 (or whatever) if you want to allow multiples of the max speed

> Oh, once you've changed it and had a play around with a ship.. go to Mesuket and watch the fun of so many Ai ships with no drag.